### PR TITLE
Mooncoin Terminal: web port of the spreadsheet game

### DIFF
--- a/mooncoin/.gitignore
+++ b/mooncoin/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.data/
+*.log

--- a/mooncoin/README.md
+++ b/mooncoin/README.md
@@ -11,12 +11,12 @@ under [Changes from the spreadsheet](#changes-from-the-spreadsheet).
 ## Running it
 
 ```bash
-npm install
-npm start            # http://localhost:3000
-npm test             # 53 tests: engine, state machine, and a live socket game
+npm start            # http://localhost:3000 — no dependencies to install
+npm test             # 66 tests: engine, state machine, and a full game over HTTP
 ```
 
-Set `PORT` to move it, `MOONCOIN_DATA` to point the snapshot file somewhere else.
+Set `PORT` to move it. Locally, games live in the server process; see
+[Deploying](#deploying) for what production needs.
 
 Three surfaces, one room code:
 
@@ -143,29 +143,56 @@ adding them later is an extension, not a rewrite.
 ## Layout
 
 ```
+api/
+  game.js        Vercel serverless entry — thin adapter over the handler
 server/
   engine.js      pricing and position math, no state, no I/O
   game.js        state machine: phases, gates, dealing, settlement
-  store.js       JSON snapshot persistence
-  index.js       HTTP + WebSocket, room fan-out
+  handler.js     the API, transport-agnostic
+  store.js       Redis over the Upstash REST API, memory when unconfigured
+  index.js       local dev server: static files + the same handler
 public/
   index.html     shell
-  app.js         all three surfaces
+  app.js         all three surfaces, polling transport
   style.css      amber-on-black terminal styling
 ```
 
-`engine.js` is pure and has no dependencies — it can be lifted out and reused.
+Zero runtime dependencies. `engine.js` is pure — no state, no I/O — so it can be
+lifted out and reused as-is.
+
+## Transport
+
+Polling, not sockets. Serverless functions cannot hold a WebSocket open, and the
+game is turn-based, so a poll tick is indistinguishable from a push. Every action
+posts and gets the resulting state straight back — whoever acted never waits for
+a tick, and the polling only exists to show you what other people did.
+
+The interval adapts: ~1.5s while you owe the table an action, ~3s once you have
+confirmed, ~0.9s during the dice, and 10s on a hidden tab. That keeps a ten-player
+table well inside a free Redis tier.
 
 ## Deploying
 
-One long-lived Node process holding WebSockets, so it wants a container host —
-Render, Railway, Fly, or any box with Node 20+. It is not a fit for the static
-Vercel deploy at the root of this repo.
+Built for Vercel. Create a **new project** pointed at this repo with the root
+directory set to `mooncoin` — same arrangement as `trading-sim`, so it deploys
+independently of the static site at the repo root. Every branch then gets its own
+preview URL.
 
-```bash
-PORT=8080 npm start
-```
+**Add a Redis store, or the game will not work properly.** Serverless functions
+share no memory, so game state has to live somewhere both requests can reach:
 
-State lives in memory and is mirrored to `.data/games.json` on a short debounce,
-so a restart or redeploy mid-game is survivable. Tables idle for twelve hours are
-swept.
+1. Vercel dashboard → **Storage** → **Upstash for Redis** → create and connect it
+   to the Mooncoin project
+2. Redeploy
+
+That injects `KV_REST_API_URL` and `KV_REST_API_TOKEN`, which the store picks up
+automatically. `UPSTASH_REDIS_REST_URL` / `_TOKEN` work too, if you bring your own
+database.
+
+Without it the app still boots, but every screen shows a warning: consecutive
+requests can land on different instances holding different games, and tables will
+appear to vanish. State carries a twelve-hour TTL, so abandoned tables clean
+themselves up.
+
+It also runs anywhere with Node 20+ — `PORT=8080 npm start` — where the in-process
+fallback is perfectly correct, because there is only ever one process.

--- a/mooncoin/README.md
+++ b/mooncoin/README.md
@@ -1,0 +1,158 @@
+# Mooncoin Terminal
+
+A web port of the Mooncoin spreadsheet game. Every player gets a private screen
+on their own phone; the shared dashboard goes on the big screen; the host drives
+the round from a third.
+
+Ported from `mooncoin base game_master` — the Google Sheet plus its Apps Script.
+Where the sheet and the design disagreed, the design won; those cases are listed
+under [Changes from the spreadsheet](#changes-from-the-spreadsheet).
+
+## Running it
+
+```bash
+npm install
+npm start            # http://localhost:3000
+npm test             # 53 tests: engine, state machine, and a live socket game
+```
+
+Set `PORT` to move it, `MOONCOIN_DATA` to point the snapshot file somewhere else.
+
+Three surfaces, one room code:
+
+| Screen | URL | Who |
+|---|---|---|
+| Player | `/ABCD` | each player, on their own device |
+| Dashboard | `/ABCD#dashboard` | the projector or TV |
+| Host | `/ABCD#host` | whoever runs the table |
+
+Open `/`, hit **New table**, and you get the code plus the host console. The host
+token lives in that browser's `localStorage`, so run the console from the machine
+that created the room. Players who reload — or whose phone sleeps — land back in
+the same seat with the same hand and blotter.
+
+## How a round works
+
+Two gates per round, matching the two ready-columns the sheet tracked. Each trips
+automatically when every seated player has confirmed; the host can force either
+one when somebody wanders off.
+
+1. **Orders** — everyone submits a signed quantity and an order type, then
+   confirms. The gate reveals the book, prints the round, and writes every
+   blotter.
+2. **Cards** — everyone plays cards and confirms. The gate reveals them and
+   computes the pressure on the dice.
+3. **Rolling** — four dice, locked one at a time. The fourth settles the round
+   and moves the mark.
+
+Orders and cards stay sealed until their gate trips. Who has confirmed is public;
+what they confirmed is not.
+
+## The market
+
+Orders carry no limit price — only a signed quantity and a type:
+
+- **MARKET** — guaranteed fill, pays the impact
+- **LIMIT** — rests, moves nothing, and only trades if market flow comes the
+  other way
+
+Only market flow enters the imbalance, so resting liquidity never moves the price
+on its own.
+
+```
+imbalance = market bid - market offer
+print     = last mark + sign(imbalance) * ceil(sqrt(|imbalance|))
+```
+
+Square-root impact is the whole governor on size. There is no position limit and
+none is needed: a 100-lot market order moves the print ten points against itself.
+
+Market orders always fill in full — that certainty is what the slippage buys.
+Limit orders fill pro-rata against opposing market flow, and the house absorbs
+whatever the resting book could not cover.
+
+## The dice
+
+Cards and regime bias the dice; they do not replace them.
+
+```
+cards.trend  = sum(up) - sum(down)          cards.mag = sum(multiply) - sum(add)
+regime.trend = +/-1 if the last two rounds agreed on direction
+regime.mag   = +/-1 if the last two rounds agreed on type
+
+net.trend = regime.trend + cards.trend
+net.mag   = regime.mag   + cards.mag
+
+trend = (trendDie + net.trend > 3) ?  +1 : -1
+type  = (typeDie  + net.mag   > 3) ? MULTIPLY : ADD
+chg   = type is MULTIPLY ? A*B*trend : (A+B)*trend
+
+newMark = mark + chg
+```
+
+Regime is trend persistence — momentum begets momentum. It needs two rounds of
+history, so it is inert until round 3.
+
+So there are two prices per round, and they are not the same number. You trade at
+the **print**, struck off the old mark by order flow. You are marked at the
+**mark**, which the dice set afterwards.
+
+## Position
+
+Pure mark-to-market, exactly as the sheet did it:
+
+```
+P/L per fill = (mark - fillPrice) * qty
+shares       = sum(qty)
+avg price    = mark - totalP/L / shares      (back-solved)
+```
+
+## Changes from the spreadsheet
+
+Four things in the sheet were broken or unbuilt rather than intended:
+
+1. **The magnitude side of NET was dead.** `Terminal!T7:T16` was hardcoded to `0`
+   instead of `=P+R`, so every multiply and add card, and the entire type-regime,
+   silently did nothing. Wired here as the mirror of the trend side.
+2. **Card inventory only decremented for `↑`.** The other three counters were
+   hardcoded, so those cards could be spent forever. All four decrement now.
+3. **The trade blotter was typed by hand.** The engine writes fills, so the
+   sheet's "Players Record Trades" step is gone.
+4. **Dealing ignored the player count.** The Apps Script always dealt ten hands
+   and silently short-handed later players once the hundred-card deck ran dry.
+   Only seated players are dealt now, and an oversubscribed deck is a hard error.
+
+Options were scaffolded in the sheet — `CALL`/`PUT` dropdowns, an `option_tickets`
+range, named ranges for ATM and expiry — but never built. They are out of scope
+here. Positions are keyed per fill rather than assuming a single instrument, so
+adding them later is an extension, not a rewrite.
+
+## Layout
+
+```
+server/
+  engine.js      pricing and position math, no state, no I/O
+  game.js        state machine: phases, gates, dealing, settlement
+  store.js       JSON snapshot persistence
+  index.js       HTTP + WebSocket, room fan-out
+public/
+  index.html     shell
+  app.js         all three surfaces
+  style.css      amber-on-black terminal styling
+```
+
+`engine.js` is pure and has no dependencies — it can be lifted out and reused.
+
+## Deploying
+
+One long-lived Node process holding WebSockets, so it wants a container host —
+Render, Railway, Fly, or any box with Node 20+. It is not a fit for the static
+Vercel deploy at the root of this repo.
+
+```bash
+PORT=8080 npm start
+```
+
+State lives in memory and is mirrored to `.data/games.json` on a short debounce,
+so a restart or redeploy mid-game is survivable. Tables idle for twelve hours are
+swept.

--- a/mooncoin/README.md
+++ b/mooncoin/README.md
@@ -52,24 +52,37 @@ what they confirmed is not.
 
 Orders carry no limit price — only a signed quantity and a type:
 
-- **MARKET** — guaranteed fill, pays the impact
-- **LIMIT** — rests, moves nothing, and only trades if market flow comes the
-  other way
+- **MARKET** — demands immediacy, always fills, pays the impact
+- **LIMIT** — rests at the last sale, absorbs pressure coming the other way, and
+  fills at the clearing price or not at all
 
-Only market flow enters the imbalance, so resting liquidity never moves the price
-on its own.
+Market orders net against each other first. Whatever pressure survives is met by
+the resting orders facing it, and only what the book cannot absorb moves the
+price:
 
 ```
-imbalance = market bid - market offer
-print     = last mark + sign(imbalance) * ceil(sqrt(|imbalance|))
+pressure  = market buys - market sells
+resting   = limit orders facing that pressure (offers if buying, bids if selling)
+absorbed  = min(|pressure|, resting)
+imbalance = sign(pressure) * (|pressure| - absorbed)
+
+print = last mark + sign(imbalance) * ceil(sqrt(|imbalance|))
 ```
+
+Everyone who trades that round trades at that one price — a single-price call
+auction, not a ladder.
+
+A resting order on the *same* side as the pressure is not marketable: nobody
+sells at last sale into a bid. It absorbs nothing and does not trade. So ten to
+buy at market plus ten more resting to buy is still an imbalance of ten.
 
 Square-root impact is the whole governor on size. There is no position limit and
-none is needed: a 100-lot market order moves the print ten points against itself.
+none is needed: a 100-lot market order into an empty book moves the print ten
+points against itself.
 
-Market orders always fill in full — that certainty is what the slippage buys.
-Limit orders fill pro-rata against opposing market flow, and the house absorbs
-whatever the resting book could not cover.
+Resting orders fill pro-rata when more is offered than the round needed. The
+house takes the other side of the imbalance, which is by construction whatever
+the players did not net out among themselves.
 
 ## The dice
 

--- a/mooncoin/api/game.js
+++ b/mooncoin/api/game.js
@@ -1,0 +1,26 @@
+/**
+ * Vercel serverless entry. All API surface goes through one function; the work
+ * happens in server/handler.js, which the local dev server runs unchanged.
+ */
+
+import { handle } from '../server/handler.js';
+
+export default async function game(req, res) {
+  let body = req.body ?? {};
+
+  // Vercel parses JSON bodies when the content type says so, but not always —
+  // read the stream ourselves when it hasn't.
+  if (req.method === 'POST' && typeof body === 'string') {
+    try { body = JSON.parse(body || '{}'); } catch { body = {}; }
+  }
+
+  const { status, body: payload } = await handle({
+    method: req.method,
+    query: req.query ?? {},
+    body,
+  });
+
+  // Polled state must never be cached — it is the whole point of polling.
+  res.setHeader('Cache-Control', 'no-store, max-age=0');
+  res.status(status).json(payload);
+}

--- a/mooncoin/package.json
+++ b/mooncoin/package.json
@@ -12,8 +12,5 @@
   },
   "engines": {
     "node": ">=20"
-  },
-  "dependencies": {
-    "ws": "^8.18.0"
   }
 }

--- a/mooncoin/package.json
+++ b/mooncoin/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "mooncoin",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Mooncoin — a multiplayer market-making game with square-root price impact",
+  "type": "module",
+  "main": "server/index.js",
+  "scripts": {
+    "start": "node server/index.js",
+    "dev": "node --watch server/index.js",
+    "test": "node --test server/*.test.js"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "dependencies": {
+    "ws": "^8.18.0"
+  }
+}

--- a/mooncoin/public/app.js
+++ b/mooncoin/public/app.js
@@ -1,0 +1,1020 @@
+/* ===========================================================================
+   MOONCOIN TERMINAL — client
+   Three surfaces off one socket: player, dashboard, host.
+   No framework, no build. State arrives, the screen is redrawn.
+   =========================================================================== */
+
+const app = document.getElementById('app');
+
+const S = {
+  role: null,        // 'player' | 'dashboard' | 'host'
+  code: null,
+  state: null,       // shared game state
+  me: null,          // private slice, players only
+  connected: false,
+  error: null,
+  notice: null,
+};
+
+const ui = {
+  side: 'BUY',
+  qty: '',
+  orderType: 'MARKET',
+  cards: { up: 0, down: 0, multiply: 0, add: 0 },
+  rolling: false,
+  name: '',
+  joinCode: '',
+  busy: false,
+  lastMark: null,
+  lastRound: null,
+  markFlash: null,
+};
+
+// --- Utilities -------------------------------------------------------------
+
+const esc = (s) => String(s ?? '').replace(/[&<>"']/g, (c) => (
+  { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]
+));
+
+const signed = (n) => (n > 0 ? `+${n}` : `${n}`);
+const cls = (n) => (n > 0 ? 'up' : n < 0 ? 'down' : 'dim');
+
+const money = (n) => {
+  const v = Math.round(n);
+  const s = Math.abs(v).toLocaleString('en-US');
+  return v < 0 ? `-$${s}` : `$${s}`;
+};
+
+const px = (n, d = 2) => (n === null || n === undefined ? '—' : Number(n).toFixed(d));
+
+const store = {
+  playerToken: (code) => localStorage.getItem(`mooncoin:player:${code}`),
+  setPlayerToken: (code, t) => localStorage.setItem(`mooncoin:player:${code}`, t),
+  hostToken: (code) => localStorage.getItem(`mooncoin:host:${code}`),
+  setHostToken: (code, t) => localStorage.setItem(`mooncoin:host:${code}`, t),
+};
+
+const CARD_META = {
+  up: { glyph: '↑', name: 'UP' },
+  down: { glyph: '↓', name: 'DOWN' },
+  multiply: { glyph: '×', name: 'MULTIPLY' },
+  add: { glyph: '+', name: 'ADD' },
+};
+
+const PHASE_LABEL = {
+  lobby: 'LOBBY',
+  orders: 'ORDER ENTRY',
+  cards: 'CARD PLAY',
+  rolling: 'ROLLING',
+  complete: 'CLOSED',
+};
+
+/** Impact preview, mirroring the server's printPrice. */
+const impactOf = (qty) => (qty === 0 ? 0 : Math.sign(qty) * Math.ceil(Math.sqrt(Math.abs(qty))));
+
+// --- Socket ----------------------------------------------------------------
+
+const net = {
+  ws: null,
+  retry: 0,
+  hello: null,
+
+  connect(hello) {
+    this.hello = { type: 'hello', ...hello };
+    const proto = location.protocol === 'https:' ? 'wss' : 'ws';
+    const ws = new WebSocket(`${proto}://${location.host}/ws`);
+    this.ws = ws;
+
+    ws.onopen = () => {
+      this.retry = 0;
+      S.connected = true;
+      S.error = null;
+      ws.send(JSON.stringify(this.hello));
+    };
+
+    ws.onmessage = (ev) => {
+      const msg = JSON.parse(ev.data);
+      if (msg.type === 'state') {
+        const prev = S.state?.mark;
+        S.state = msg.state;
+        if (msg.me) S.me = msg.me;
+        if (prev !== undefined && msg.state.mark !== prev) {
+          ui.markFlash = msg.state.mark > prev ? 'flash-up' : 'flash-down';
+          setTimeout(() => { ui.markFlash = null; render(); }, 750);
+        }
+        // Clear the ticket when the round turns over, and only then — every
+        // player action broadcasts, and wiping on each one would erase a
+        // quantity somebody is halfway through typing.
+        const turned = ui.lastRound !== null && ui.lastRound !== msg.state.round;
+        if (turned) {
+          ui.qty = '';
+          ui.cards = { up: 0, down: 0, multiply: 0, add: 0 };
+        }
+        ui.lastRound = msg.state.round;
+        render();
+      } else if (msg.type === 'seated') {
+        store.setPlayerToken(S.code, msg.playerToken);
+      } else if (msg.type === 'die') {
+        ui.rolling = false;
+        render();
+      } else if (msg.type === 'error') {
+        S.error = msg.message;
+        ui.busy = false;
+        ui.rolling = false;
+        render();
+      }
+    };
+
+    ws.onclose = () => {
+      S.connected = false;
+      render();
+      // Back off, but keep trying — a phone that slept should rejoin on its own.
+      this.retry = Math.min(this.retry + 1, 6);
+      setTimeout(() => this.connect(this.hello), 400 * 2 ** (this.retry - 1));
+    };
+
+    ws.onerror = () => ws.close();
+  },
+
+  send(msg) {
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      S.error = null;
+      this.ws.send(JSON.stringify(msg));
+    }
+  },
+};
+
+// --- Actions ---------------------------------------------------------------
+
+const act = {
+  setSide(side) { ui.side = side; render(); },
+  setType(t) { ui.orderType = t; render(); },
+  setQty(v) { ui.qty = v.replace(/[^0-9]/g, ''); },
+
+  submitOrder() {
+    const mag = parseInt(ui.qty || '0', 10);
+    if (!Number.isFinite(mag) || mag < 0) { S.error = 'Enter a quantity'; return render(); }
+    const qty = ui.side === 'SELL' ? -mag : mag;
+    net.send({ type: 'order', qty, orderType: ui.orderType });
+    net.send({ type: 'confirmOrder' });
+  },
+
+  passOrder() {
+    net.send({ type: 'order', qty: 0, orderType: 'LIMIT' });
+    net.send({ type: 'confirmOrder' });
+  },
+
+  unconfirmOrder() { net.send({ type: 'unconfirmOrder' }); },
+
+  bumpCard(kind, delta) {
+    const held = S.me?.hand?.[kind] ?? 0;
+    ui.cards[kind] = Math.max(0, Math.min(held, (ui.cards[kind] ?? 0) + delta));
+    render();
+  },
+
+  submitCards() {
+    net.send({ type: 'cards', cards: ui.cards });
+    net.send({ type: 'confirmCards' });
+  },
+
+  unconfirmCards() { net.send({ type: 'unconfirmCards' }); },
+
+  roll() {
+    ui.rolling = true;
+    render();
+    setTimeout(() => net.send({ type: 'roll' }), 420);   // let the tumble register
+  },
+
+  start() { net.send({ type: 'start' }); },
+  force() { net.send({ type: 'force' }); },
+  reset() {
+    if (confirm('Reset the game? Every position and hand is wiped. Seats stay.')) {
+      net.send({ type: 'reset' });
+    }
+  },
+  kick(playerId, name) {
+    if (confirm(`Remove ${name} from the table?`)) net.send({ type: 'kick', playerId });
+  },
+  config(patch) { net.send({ type: 'config', config: patch }); },
+
+  copy(text, label) {
+    navigator.clipboard?.writeText(text).then(() => {
+      S.notice = `${label} copied`;
+      render();
+      setTimeout(() => { S.notice = null; render(); }, 1600);
+    });
+  },
+};
+
+// --- Shared chrome ---------------------------------------------------------
+
+function topbar(extra = '') {
+  const st = S.state;
+  const conn = S.connected
+    ? '<span class="chip live">LIVE</span>'
+    : '<span class="chip off">RECONNECTING</span>';
+  const round = st && st.round > 0 ? `R${st.round}/${st.maxRounds}` : '—';
+  return `
+    <div class="topbar">
+      <span>MOONCOIN</span>
+      <span class="chip">${esc(S.code ?? '')}</span>
+      <span>${esc(round)}</span>
+      <span>${esc(st ? PHASE_LABEL[st.phase] : '')}</span>
+      ${extra}
+      <span class="spacer"></span>
+      ${conn}
+    </div>`;
+}
+
+function alerts() {
+  return `
+    ${S.error ? `<div class="err">${esc(S.error)}</div>` : ''}
+    ${S.notice ? `<div class="ok">${esc(S.notice)}</div>` : ''}`;
+}
+
+function ladder(book) {
+  const b = book ?? { limitBid: 0, marketBid: 0, imbalance: 0, marketOffer: 0, limitOffer: 0 };
+  const cell = (label, qty, kind) => `
+    <div class="${kind}">
+      <div class="label">${label}</div>
+      <div class="qty">${qty}</div>
+    </div>`;
+  return `
+    <div class="ladder">
+      ${cell('Limit Bid', b.limitBid, 'bid')}
+      ${cell('Market Bid', b.marketBid, 'bid')}
+      <div class="imb">
+        <div class="label">Imbalance</div>
+        <div class="qty ${cls(b.imbalance)}">${signed(b.imbalance)}</div>
+      </div>
+      ${cell('Market Offer', b.marketOffer, 'offer')}
+      ${cell('Limit Offer', b.limitOffer, 'offer')}
+    </div>`;
+}
+
+function diceRow(st, dice = st.dice, live = true) {
+  const labels = ['Trend Die', 'Multiply/Add', 'D6 (A)', 'D6 (B)'];
+  const next = live ? st.rollStep : -1;
+  return `
+    <div class="dice">
+      ${dice.map((d, i) => {
+        const locked = d !== null;
+        const isNext = live && !locked && i === next && st.phase === 'rolling';
+        const tumbling = isNext && ui.rolling;
+        const klass = ['die', locked ? 'locked' : 'empty', isNext ? 'next' : '', tumbling ? 'rolling' : '']
+          .filter(Boolean).join(' ');
+        return `
+          <div class="${klass}">
+            <div class="cap">${labels[i]}</div>
+            <div class="pip">${locked ? d : tumbling ? '?' : '·'}</div>
+            <div class="cap">${locked ? 'LOCKED' : isNext ? 'NEXT' : ''}</div>
+          </div>`;
+      }).join('')}
+    </div>`;
+}
+
+function waitingPills(st, list) {
+  if (!st.standings.length) return '<span class="dim">No players seated</span>';
+  return `<div class="waiting">${st.standings.map((p) => {
+    const late = list.includes(p.name);
+    const k = !p.connected ? 'gone' : late ? 'late' : 'ready';
+    const mark = !p.connected ? '∅' : late ? '·' : '✓';
+    return `<span class="pill ${k}">${mark} ${esc(p.name)}</span>`;
+  }).join('')}</div>`;
+}
+
+function standingsTable(st, opts = {}) {
+  const rows = st.standings.map((p, i) => `
+    <tr class="${opts.meId === p.id ? 'me' : ''}">
+      <td class="num dim">${i + 1}</td>
+      <td class="strong">${esc(p.name)}${p.connected ? '' : ' <span class="grey tiny">OFF</span>'}</td>
+      <td class="num ${cls(p.shares)}">${signed(p.shares)}</td>
+      <td class="num dim">${p.avgPrice === null ? '—' : px(p.avgPrice)}</td>
+      <td class="num strong ${cls(p.pl)}">${money(p.pl)}</td>
+      <td class="num dim">${p.cardsLeft}</td>
+      ${opts.host ? `<td class="num"><button class="danger" data-kick="${p.id}" data-name="${esc(p.name)}">×</button></td>` : ''}
+    </tr>`).join('');
+
+  return `
+    <div class="scroll-x">
+      <table>
+        <thead><tr>
+          <th class="num">#</th><th>Player</th><th class="num">Pos</th>
+          <th class="num">Avg</th><th class="num">P/L</th><th class="num">Cards</th>
+          ${opts.host ? '<th></th>' : ''}
+        </tr></thead>
+        <tbody>${rows || '<tr><td colspan="7" class="dim">No players seated</td></tr>'}</tbody>
+      </table>
+    </div>`;
+}
+
+function historyTable(st) {
+  if (!st.history.length) {
+    return '<div class="body dim">No rounds settled yet.</div>';
+  }
+  const rows = st.history.slice().reverse().map((h) => `
+    <tr>
+      <td class="num strong">${h.round}</td>
+      <td class="num dim">${h.limitBid}</td>
+      <td class="num up">${h.marketBid}</td>
+      <td class="num strong ${cls(h.imbalance)}">${signed(h.imbalance)}</td>
+      <td class="num down">${h.marketOffer}</td>
+      <td class="num dim">${h.limitOffer}</td>
+      <td class="num strong">${h.print}</td>
+      <td class="num dim">${h.dice.join(' ')}</td>
+      <td class="num ${cls(h.net.trend)}">${signed(h.net.trend)}</td>
+      <td class="num ${cls(h.net.mag)}">${signed(h.net.mag)}</td>
+      <td>${h.type === 'MULTIPLY' ? '×' : '+'}</td>
+      <td class="num strong ${cls(h.chg)}">${signed(h.chg)}</td>
+      <td class="num strong">${h.mark}</td>
+    </tr>`).join('');
+
+  return `
+    <div class="scroll-x">
+      <table>
+        <thead><tr>
+          <th class="num">R</th><th class="num">LB</th><th class="num">MB</th>
+          <th class="num">IMB</th><th class="num">MO</th><th class="num">LO</th>
+          <th class="num">Print</th><th class="num">Dice</th>
+          <th class="num">Trend</th><th class="num">Mag</th><th>Type</th>
+          <th class="num">Chg</th><th class="num">Mark</th>
+        </tr></thead>
+        <tbody>${rows}</tbody>
+      </table>
+    </div>`;
+}
+
+function tape(st) {
+  return `<div class="tape">${st.log.slice().reverse().map((l) => `
+    <div><span class="t">R${l.round}</span>${esc(l.text)}</div>`).join('')}</div>`;
+}
+
+function markPanel(st) {
+  const last = st.history[st.history.length - 1];
+  const chg = last?.chg ?? 0;
+  return `
+    <div class="panel">
+      <header>Mooncoin <span class="spacer"></span><span class="note">Opened ${st.openingPrice}</span></header>
+      <div class="tiles">
+        <div class="readout ${ui.markFlash ?? ''}">
+          <div class="label">Mark</div>
+          <div class="value">${st.mark}</div>
+        </div>
+        <div class="readout">
+          <div class="label">Last Change</div>
+          <div class="value ${cls(chg)}">${st.history.length ? signed(chg) : '—'}</div>
+        </div>
+        <div class="readout">
+          <div class="label">Last Print</div>
+          <div class="value">${last?.print ?? '—'}</div>
+        </div>
+        <div class="readout">
+          <div class="label">Round</div>
+          <div class="value">${st.round || '—'}<span class="dim" style="font-size:14px">/${st.maxRounds}</span></div>
+        </div>
+      </div>
+    </div>`;
+}
+
+// --- Home ------------------------------------------------------------------
+
+function renderHome() {
+  app.innerHTML = `
+    ${topbar()}
+    <div class="home">
+      <div class="brand">
+        <div class="logo">MOONCOIN</div>
+        <div class="sub">TERMINAL</div>
+        <div class="rule"></div>
+      </div>
+      ${alerts()}
+      <div class="stack">
+        <div class="panel">
+          <header>Join a table</header>
+          <div class="body">
+            <label class="field">
+              <span>Room code</span>
+              <input id="joinCode" class="code-in" maxlength="4" autocomplete="off"
+                     autocapitalize="characters" placeholder="————"
+                     value="${esc(ui.joinCode)}">
+            </label>
+            <button class="primary wide lg" id="joinBtn">Enter</button>
+          </div>
+        </div>
+        <div class="panel ghost">
+          <header>Run a table</header>
+          <div class="body">
+            <p class="dim" style="margin-top:0">
+              Opens a new room. You get the host console, the dashboard for the big
+              screen, and a code for the players.
+            </p>
+            <button class="wide lg" id="createBtn" ${ui.busy ? 'disabled' : ''}>
+              ${ui.busy ? 'Opening…' : 'New table'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>`;
+
+  const code = document.getElementById('joinCode');
+  code.oninput = (e) => { ui.joinCode = e.target.value.toUpperCase().replace(/[^A-Z0-9]/g, ''); e.target.value = ui.joinCode; };
+  code.onkeydown = (e) => { if (e.key === 'Enter') go(); };
+
+  const go = () => {
+    if (ui.joinCode.length !== 4) { S.error = 'Room codes are four characters'; return render(); }
+    location.href = `/${ui.joinCode}`;
+  };
+  document.getElementById('joinBtn').onclick = go;
+
+  document.getElementById('createBtn').onclick = async () => {
+    ui.busy = true; render();
+    try {
+      const res = await fetch('/api/games', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}' });
+      if (!res.ok) throw new Error('Could not open a table');
+      const { code: newCode, hostToken } = await res.json();
+      store.setHostToken(newCode, hostToken);
+      location.href = `/${newCode}#host`;
+    } catch (err) {
+      S.error = err.message;
+      ui.busy = false;
+      render();
+    }
+  };
+}
+
+// --- Player: name prompt ---------------------------------------------------
+
+function renderJoin() {
+  app.innerHTML = `
+    ${topbar()}
+    <div class="home">
+      <div class="brand">
+        <div class="logo">MOONCOIN</div>
+        <div class="sub">TABLE ${esc(S.code)}</div>
+        <div class="rule"></div>
+      </div>
+      ${alerts()}
+      <div class="panel">
+        <header>Take a seat</header>
+        <div class="body">
+          <label class="field">
+            <span>Trader name</span>
+            <input id="name" maxlength="20" autocomplete="off" placeholder="KRIS" value="${esc(ui.name)}">
+          </label>
+          <button class="primary wide lg" id="sit">Sit down</button>
+        </div>
+      </div>
+      <div class="row" style="margin-top:8px;justify-content:center">
+        <a href="/${esc(S.code)}#dashboard" class="dim">Open the dashboard instead</a>
+      </div>
+    </div>`;
+
+  const input = document.getElementById('name');
+  input.oninput = (e) => { ui.name = e.target.value; };
+  input.onkeydown = (e) => { if (e.key === 'Enter') sit(); };
+  input.focus();
+
+  const sit = () => {
+    if (!ui.name.trim()) { S.error = 'Name required'; return render(); }
+    net.connect({ role: 'player', code: S.code, name: ui.name.trim() });
+    S.role = 'player';
+    render();
+  };
+  document.getElementById('sit').onclick = sit;
+}
+
+// --- Player terminal -------------------------------------------------------
+
+function orderTicket(st, me) {
+  if (me.ordersReady) {
+    const o = me.pendingOrder;
+    const side = o.qty > 0 ? 'BUY' : o.qty < 0 ? 'SELL' : 'PASS';
+    return `
+      <div class="body">
+        <div class="banner">Order confirmed</div>
+        <div class="tiles" style="border:1px solid var(--rule);border-top:none">
+          <div class="readout"><div class="label">Side</div><div class="value ${o.qty > 0 ? 'up' : o.qty < 0 ? 'down' : 'dim'}">${side}</div></div>
+          <div class="readout"><div class="label">Qty</div><div class="value">${Math.abs(o.qty)}</div></div>
+          <div class="readout"><div class="label">Type</div><div class="value">${o.type}</div></div>
+        </div>
+        <div class="row" style="margin-top:8px">
+          <button id="unconfirmOrder">Pull it back</button>
+          <span class="dim">Waiting on ${st.awaitingOrders.length ? esc(st.awaitingOrders.join(', ')) : 'nobody — opening now'}</span>
+        </div>
+      </div>`;
+  }
+
+  const mag = parseInt(ui.qty || '0', 10) || 0;
+  const signedQty = ui.side === 'SELL' ? -mag : mag;
+  const slip = ui.orderType === 'MARKET' ? impactOf(signedQty) : 0;
+  const est = st.mark + slip;
+
+  return `
+    <div class="body">
+      <div class="split" style="margin-bottom:6px">
+        <button class="buy ${ui.side === 'BUY' ? 'on' : ''}" data-side="BUY">Buy</button>
+        <button class="sell ${ui.side === 'SELL' ? 'on' : ''}" data-side="SELL">Sell</button>
+      </div>
+      <label class="field">
+        <span>Quantity</span>
+        <input id="qty" class="num" inputmode="numeric" autocomplete="off" placeholder="0" value="${esc(ui.qty)}">
+      </label>
+      <div class="split" style="margin-bottom:8px">
+        <button class="${ui.orderType === 'MARKET' ? 'on' : ''}" data-otype="MARKET">Market</button>
+        <button class="${ui.orderType === 'LIMIT' ? 'on' : ''}" data-otype="LIMIT">Limit</button>
+      </div>
+      <div class="tiles" style="border:1px solid var(--rule);margin-bottom:8px">
+        <div class="readout">
+          <div class="label">${ui.orderType === 'MARKET' ? 'Est. Print' : 'Fills At'}</div>
+          <div class="value">${ui.orderType === 'MARKET' ? est : st.mark}<span class="dim" style="font-size:12px"> ${ui.orderType === 'MARKET' ? 'if alone' : 'or better'}</span></div>
+        </div>
+        <div class="readout">
+          <div class="label">Your Slippage</div>
+          <div class="value ${slip === 0 ? 'dim' : 'down'}">${ui.orderType === 'MARKET' ? signed(slip) : '0'}</div>
+        </div>
+      </div>
+      <p class="dim tiny" style="margin:0 0 8px">
+        ${ui.orderType === 'MARKET'
+          ? 'Market fills for certain and pays √imbalance in impact.'
+          : 'Limit rests. It moves nothing and only trades if market flow comes the other way.'}
+      </p>
+      <div class="split">
+        <button id="pass">Pass</button>
+        <button class="primary" id="submitOrder">Confirm</button>
+      </div>
+    </div>`;
+}
+
+function cardTicket(st, me) {
+  if (me.cardsReady) {
+    const c = me.pendingCards ?? { up: 0, down: 0, multiply: 0, add: 0 };
+    const total = Object.values(c).reduce((a, b) => a + b, 0);
+    return `
+      <div class="body">
+        <div class="banner">Cards confirmed</div>
+        <div class="body center dim" style="padding:10px 0">
+          ${total === 0 ? 'Holding everything back this round.'
+            : Object.entries(c).filter(([, n]) => n > 0)
+                .map(([k, n]) => `${n}× ${CARD_META[k].glyph}`).join('  ')}
+        </div>
+        <div class="row">
+          <button id="unconfirmCards">Take them back</button>
+          <span class="dim">Waiting on ${st.awaitingCards.length ? esc(st.awaitingCards.join(', ')) : 'nobody'}</span>
+        </div>
+      </div>`;
+  }
+
+  return `
+    <div class="body">
+      <div class="cardgrid">
+        ${Object.keys(CARD_META).map((k) => {
+          const held = me.hand[k];
+          const picked = ui.cards[k] ?? 0;
+          return `
+            <div class="card ${k} ${held === 0 ? 'spent' : ''}">
+              <div class="glyph">${CARD_META[k].glyph}</div>
+              <div class="name">${CARD_META[k].name}</div>
+              <div class="held">${held - picked} left</div>
+              <div class="picked">${picked}</div>
+              <div class="stepper">
+                <button data-card="${k}" data-delta="-1" ${picked === 0 ? 'disabled' : ''}>−</button>
+                <button data-card="${k}" data-delta="1" ${picked >= held ? 'disabled' : ''}>+</button>
+              </div>
+            </div>`;
+        }).join('')}
+      </div>
+      <p class="dim tiny" style="margin:8px 0">
+        ↑/↓ push the trend die. ×/+ push the magnitude die. Everything is spent whether it lands or not.
+      </p>
+      <button class="primary wide" id="submitCards">Confirm cards</button>
+    </div>`;
+}
+
+function blotter(me) {
+  if (!me.fills.length) return '<div class="body dim">No fills yet.</div>';
+  return `
+    <div class="scroll-x">
+      <table>
+        <thead><tr>
+          <th class="num">R</th><th class="num">Qty</th><th class="num">Price</th><th class="num">P/L</th>
+        </tr></thead>
+        <tbody>${me.fills.slice().reverse().map((f) => {
+          const pl = (S.state.mark - f.price) * f.qty;
+          return `<tr>
+            <td class="num dim">${f.round}</td>
+            <td class="num ${cls(f.qty)}">${signed(f.qty)}</td>
+            <td class="num">${f.price}</td>
+            <td class="num ${cls(pl)}">${money(pl)}</td>
+          </tr>`;
+        }).join('')}</tbody>
+      </table>
+    </div>`;
+}
+
+function renderPlayer() {
+  const st = S.state;
+  const me = S.me;
+  if (!st || !me) {
+    app.innerHTML = `${topbar()}<div class="wrap"><div class="banner wait blink">Connecting</div>${alerts()}</div>`;
+    return;
+  }
+
+  const rank = st.standings.findIndex((p) => p.id === me.id) + 1;
+  const lastRound = st.history[st.history.length - 1];
+
+  let ticket;
+  if (st.phase === 'lobby') {
+    ticket = `<div class="body"><div class="banner wait blink">Waiting for the host to open</div>
+      <p class="dim center" style="margin:10px 0 0">${st.seated} seated</p></div>`;
+  } else if (st.phase === 'orders') {
+    ticket = orderTicket(st, me);
+  } else if (st.phase === 'cards') {
+    ticket = cardTicket(st, me);
+  } else if (st.phase === 'rolling') {
+    ticket = `<div class="body">${diceRow(st)}
+      <p class="center dim" style="margin:8px 0 0">${st.rollStep}/4 locked — host is rolling</p></div>`;
+  } else {
+    const winner = st.standings[0];
+    ticket = `<div class="body">
+      <div class="banner">Market closed</div>
+      <div class="readout center" style="margin-top:10px">
+        <div class="label">Winner</div>
+        <div class="value">${esc(winner?.name ?? '—')}</div>
+        <div class="dim">${winner ? money(winner.pl) : ''}</div>
+      </div></div>`;
+  }
+
+  app.innerHTML = `
+    ${topbar(`<span class="chip">${esc(me.name)}</span>`)}
+    <div class="wrap">
+      ${alerts()}
+      <div class="tiles panel">
+        <div class="readout ${ui.markFlash ?? ''}">
+          <div class="label">Mark</div><div class="value">${st.mark}</div>
+        </div>
+        <div class="readout">
+          <div class="label">Position</div><div class="value ${cls(me.shares)}">${signed(me.shares)}</div>
+        </div>
+        <div class="readout">
+          <div class="label">Avg Price</div><div class="value">${me.avgPrice === null ? '—' : px(me.avgPrice)}</div>
+        </div>
+        <div class="readout">
+          <div class="label">P/L</div><div class="value ${cls(me.pl)}">${money(me.pl)}</div>
+        </div>
+        <div class="readout">
+          <div class="label">Rank</div><div class="value">${rank || '—'}<span class="dim" style="font-size:13px">/${st.seated}</span></div>
+        </div>
+      </div>
+
+      <div class="cols">
+        <div class="panel">
+          <header>
+            ${st.phase === 'cards' ? 'Cards' : 'Order Ticket'}
+            <span class="spacer"></span>
+            <span class="note">${PHASE_LABEL[st.phase]}</span>
+          </header>
+          ${ticket}
+        </div>
+
+        <div class="stack">
+          ${st.reveal ? `
+            <div class="panel">
+              <header>Round ${st.round} Book <span class="spacer"></span>
+                <span class="note">printed ${st.reveal.price}</span></header>
+              ${ladder(st.reveal)}
+              ${st.reveal.houseResidual > 0 ? `<div class="body dim tiny">House absorbed ${st.reveal.houseResidual}</div>` : ''}
+            </div>` : ''}
+          <div class="panel">
+            <header>Blotter <span class="spacer"></span><span class="note">${me.fills.length} fills</span></header>
+            ${blotter(me)}
+          </div>
+          <div class="panel">
+            <header>Hand</header>
+            <div class="body">
+              <div class="cardgrid">
+                ${Object.keys(CARD_META).map((k) => `
+                  <div class="card ${k} ${me.hand[k] === 0 ? 'spent' : ''}">
+                    <div class="glyph">${CARD_META[k].glyph}</div>
+                    <div class="held">${me.hand[k]}</div>
+                  </div>`).join('')}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="cols">
+        <div class="panel">
+          <header>Standings</header>
+          ${standingsTable(st, { meId: me.id })}
+        </div>
+        <div class="panel">
+          <header>Tape</header>
+          ${tape(st)}
+        </div>
+      </div>
+
+      ${lastRound ? `
+        <div class="panel">
+          <header>Round History</header>
+          ${historyTable(st)}
+        </div>` : ''}
+    </div>`;
+
+  wirePlayer();
+}
+
+function wirePlayer() {
+  const qty = document.getElementById('qty');
+  if (qty) {
+    // Redraw on every keystroke so the slippage preview tracks the size. The
+    // caret survives because render() restores it.
+    qty.oninput = (e) => {
+      act.setQty(e.target.value);
+      e.target.value = ui.qty;
+      render();
+    };
+    qty.onkeydown = (e) => { if (e.key === 'Enter') act.submitOrder(); };
+  }
+
+  document.querySelectorAll('[data-side]').forEach((b) => {
+    b.onclick = () => act.setSide(b.dataset.side);
+  });
+  document.querySelectorAll('[data-otype]').forEach((b) => {
+    b.onclick = () => act.setType(b.dataset.otype);
+  });
+  document.querySelectorAll('[data-card]').forEach((b) => {
+    b.onclick = () => act.bumpCard(b.dataset.card, Number(b.dataset.delta));
+  });
+
+  const on = (id, fn) => { const el = document.getElementById(id); if (el) el.onclick = fn; };
+  on('submitOrder', act.submitOrder);
+  on('pass', act.passOrder);
+  on('unconfirmOrder', act.unconfirmOrder);
+  on('submitCards', act.submitCards);
+  on('unconfirmCards', act.unconfirmCards);
+}
+
+// --- Dashboard -------------------------------------------------------------
+
+function renderDashboard(hostMode = false) {
+  const st = S.state;
+  if (!st) {
+    app.innerHTML = `${topbar()}<div class="wrap"><div class="banner wait blink">Connecting</div>${alerts()}</div>`;
+    return;
+  }
+
+  const joinUrl = `${location.origin}/${st.code}`;
+  const gateList = st.phase === 'orders' ? st.awaitingOrders
+    : st.phase === 'cards' ? st.awaitingCards : [];
+
+  // Between rounds the live slots are empty. Rather than blank three panels,
+  // fall back to the last settled round — a terminal shows the last print, it
+  // does not go dark.
+  const last = st.history[st.history.length - 1];
+  const liveBook = !!st.reveal;
+  const book = st.reveal ?? (last ? {
+    limitBid: last.limitBid, marketBid: last.marketBid, imbalance: last.imbalance,
+    marketOffer: last.marketOffer, limitOffer: last.limitOffer,
+    price: last.print, houseResidual: last.houseResidual,
+  } : null);
+  const bookRound = liveBook ? st.round : last?.round;
+
+  const liveDice = st.dice.some((d) => d !== null);
+  const dice = liveDice ? st.dice : (last?.dice ?? null);
+  const diceRound = liveDice ? st.round : last?.round;
+
+  const liveNet = !!st.net;
+  const net = st.net ?? (last ? { cards: last.cards, regime: last.regime, plays: last.plays } : null);
+  const netRound = liveNet ? st.round : last?.round;
+
+  const controls = hostMode ? `
+    <div class="panel">
+      <header>Host Console <span class="spacer"></span>
+        <span class="note">${PHASE_LABEL[st.phase]}</span></header>
+      <div class="body stack">
+        ${st.phase === 'lobby' ? `
+          <div class="split">
+            <label class="field">
+              <span>Rounds</span>
+              <input id="cfgRounds" class="num" value="${st.maxRounds}" inputmode="numeric">
+            </label>
+            <label class="field">
+              <span>Cards each</span>
+              <input id="cfgCards" class="num" value="${st.cardQty}" inputmode="numeric">
+            </label>
+          </div>
+          <button class="primary wide lg" id="start" ${st.seated < 1 ? 'disabled' : ''}>
+            ${st.seated < 1 ? 'Waiting for players' : `Open the market (${st.seated} seated)`}
+          </button>` : ''}
+
+        ${st.phase === 'orders' || st.phase === 'cards' ? `
+          <button class="wide" id="force">
+            Force the ${st.phase === 'orders' ? 'orders' : 'cards'} gate
+            ${gateList.length ? `— skips ${esc(gateList.join(', '))}` : ''}
+          </button>` : ''}
+
+        ${st.phase === 'rolling' ? `
+          <button class="primary wide lg" id="roll" ${ui.rolling ? 'disabled' : ''}>
+            ${ui.rolling ? 'Rolling…' : `Roll ${st.dieLabel ?? ''} (${st.rollStep + 1}/4)`}
+          </button>` : ''}
+
+        ${st.phase === 'complete' ? '<div class="banner">Market closed</div>' : ''}
+
+        <div class="row">
+          <button id="copyJoin">Copy join link</button>
+          <button id="openDash">Open dashboard</button>
+          <button class="danger" id="reset">Reset</button>
+        </div>
+      </div>
+    </div>` : '';
+
+  app.innerHTML = `
+    ${topbar()}
+    <div class="wrap ${hostMode ? '' : 'dashboard'}">
+      ${alerts()}
+      ${st.phase === 'lobby' ? `
+        <div class="panel">
+          <header>Table open — join at ${esc(location.host)}</header>
+          <div class="body center">
+            <div class="huge" style="letter-spacing:0.28em">${esc(st.code)}</div>
+            <div class="dim">${esc(joinUrl)}</div>
+            <div style="margin-top:14px">${waitingPills(st, st.standings.map((p) => p.name))}</div>
+          </div>
+        </div>` : ''}
+
+      ${markPanel(st)}
+
+      <div class="${hostMode ? 'cols-2-1' : 'cols'}">
+        <div class="stack">
+          <div class="panel">
+            <header>
+              ${book ? `Round ${bookRound} Book` : 'Order Book'}
+              <span class="spacer"></span>
+              <span class="note">${book
+                ? `printed ${book.price}${liveBook ? '' : ' · last settled'}`
+                : 'sealed until the gate trips'}</span>
+            </header>
+            ${ladder(book)}
+            ${book?.houseResidual > 0
+              ? `<div class="body dim tiny">House absorbed ${book.houseResidual} — resting book could not cover the market flow</div>`
+              : ''}
+          </div>
+
+          ${dice ? `
+            <div class="panel">
+              <header>Round ${diceRound} Dice <span class="spacer"></span>
+                <span class="note">${st.net
+                  ? `net trend ${signed(st.net.trend)} · net magnitude ${signed(st.net.mag)}`
+                  : last ? `${last.type === 'MULTIPLY' ? '×' : '+'} ${signed(last.chg)} to ${last.mark}` : ''}</span></header>
+              <div class="body">${diceRow(st, dice, liveDice)}</div>
+            </div>` : ''}
+
+          ${net ? `
+            <div class="panel">
+              <header>Round ${netRound} Cards <span class="spacer"></span>
+                <span class="note">${liveNet ? '' : 'last settled'}</span></header>
+              <div class="scroll-x">
+                <table>
+                  <thead><tr><th>Player</th><th class="num">↑</th><th class="num">↓</th>
+                    <th class="num">×</th><th class="num">+</th></tr></thead>
+                  <tbody>
+                    ${(net.plays ?? []).map((p) => `
+                      <tr><td>${esc(p.name)}</td>
+                        <td class="num ${p.up ? 'up' : 'dim'}">${p.up}</td>
+                        <td class="num ${p.down ? 'down' : 'dim'}">${p.down}</td>
+                        <td class="num ${p.multiply ? 'cyan' : 'dim'}">${p.multiply}</td>
+                        <td class="num ${p.add ? 'cyan' : 'dim'}">${p.add}</td></tr>`).join('')}
+                    <tr><td class="strong">CARDS</td>
+                      <td class="num strong" colspan="2">trend ${signed(net.cards.trend)}</td>
+                      <td class="num strong" colspan="2">mag ${signed(net.cards.mag)}</td></tr>
+                    <tr><td class="dim">REGIME</td>
+                      <td class="num dim" colspan="2">trend ${signed(net.regime.trend)}</td>
+                      <td class="num dim" colspan="2">mag ${signed(net.regime.mag)}</td></tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>` : ''}
+        </div>
+
+        <div class="stack">
+          ${controls}
+          ${st.phase === 'orders' || st.phase === 'cards' ? `
+            <div class="panel">
+              <header>Waiting On <span class="spacer"></span>
+                <span class="note">${gateList.length} of ${st.seated}</span></header>
+              <div class="body">${waitingPills(st, gateList)}</div>
+            </div>` : ''}
+          <div class="panel">
+            <header>Standings</header>
+            ${/* Seats can only be removed in the lobby, so the control is only offered there. */ ''}
+            ${standingsTable(st, { host: hostMode && st.phase === 'lobby' })}
+          </div>
+          <div class="panel">
+            <header>Tape</header>
+            ${tape(st)}
+          </div>
+        </div>
+      </div>
+
+      <div class="panel">
+        <header>Round History</header>
+        ${historyTable(st)}
+      </div>
+    </div>`;
+
+  if (hostMode) wireHost(st, joinUrl);
+}
+
+function wireHost(st, joinUrl) {
+  const on = (id, fn) => { const el = document.getElementById(id); if (el) el.onclick = fn; };
+  on('start', () => {
+    const rounds = document.getElementById('cfgRounds');
+    const cards = document.getElementById('cfgCards');
+    if (rounds && cards) {
+      act.config({ maxRounds: Number(rounds.value), cardQty: Number(cards.value) });
+    }
+    setTimeout(act.start, 60);   // let the config land before the deal
+  });
+  on('force', act.force);
+  on('roll', act.roll);
+  on('reset', act.reset);
+  on('copyJoin', () => act.copy(joinUrl, 'Join link'));
+  on('openDash', () => window.open(`/${st.code}#dashboard`, '_blank'));
+
+  document.querySelectorAll('[data-kick]').forEach((b) => {
+    b.onclick = () => act.kick(b.dataset.kick, b.dataset.name);
+  });
+}
+
+// --- Render / route --------------------------------------------------------
+
+/** Preserve focus and caret across a full redraw. */
+function render() {
+  const active = document.activeElement;
+  const id = active?.id;
+  const start = active?.selectionStart;
+  const end = active?.selectionEnd;
+
+  if (!S.code) renderHome();
+  else if (S.role === 'player') renderPlayer();
+  else if (S.role === 'host') renderDashboard(true);
+  else if (S.role === 'dashboard') renderDashboard(false);
+  else renderJoin();
+
+  if (id) {
+    const el = document.getElementById(id);
+    if (el) {
+      el.focus();
+      if (start !== undefined && start !== null && el.setSelectionRange) {
+        try { el.setSelectionRange(start, end); } catch { /* not a text input */ }
+      }
+    }
+  }
+}
+
+function route() {
+  const path = location.pathname.replace(/^\/+|\/+$/g, '').toUpperCase();
+  const hash = location.hash.replace('#', '');
+
+  if (!/^[A-Z0-9]{4}$/.test(path)) {
+    S.code = null;
+    S.role = null;
+    return render();
+  }
+
+  S.code = path;
+
+  if (hash === 'host') {
+    const t = store.hostToken(path);
+    if (!t) {
+      S.error = 'No host credentials for this table on this device. Open it from the machine that created it, or run the dashboard instead.';
+      S.role = 'dashboard';
+      net.connect({ role: 'dashboard', code: path });
+      return render();
+    }
+    S.role = 'host';
+    net.connect({ role: 'host', code: path, hostToken: t });
+    return render();
+  }
+
+  if (hash === 'dashboard') {
+    S.role = 'dashboard';
+    net.connect({ role: 'dashboard', code: path });
+    return render();
+  }
+
+  // Player: reconnect silently if this device already has a seat.
+  const token = store.playerToken(path);
+  if (token) {
+    S.role = 'player';
+    net.connect({ role: 'player', code: path, playerToken: token });
+    return render();
+  }
+
+  S.role = null;   // prompt for a name
+  render();
+}
+
+window.addEventListener('hashchange', () => location.reload());
+route();

--- a/mooncoin/public/app.js
+++ b/mooncoin/public/app.js
@@ -14,6 +14,7 @@ const S = {
   connected: false,
   error: null,
   notice: null,
+  ephemeral: false,   // server has no Redis — state may not survive between requests
 };
 
 const ui = {
@@ -74,75 +75,119 @@ const impactOf = (qty) => (qty === 0 ? 0 : Math.sign(qty) * Math.ceil(Math.sqrt(
 
 // --- Socket ----------------------------------------------------------------
 
+/**
+ * Transport: polling.
+ *
+ * The game is turn-based, so a poll tick is indistinguishable from a push, and
+ * it runs on serverless where a socket cannot. Every action posts and gets the
+ * resulting state straight back, so whoever acted never waits for a tick — the
+ * polling only exists to show you what other people did.
+ */
 const net = {
-  ws: null,
-  retry: 0,
-  hello: null,
+  timer: null,
+  token: null,
+  failures: 0,
 
-  connect(hello) {
-    this.hello = { type: 'hello', ...hello };
-    const proto = location.protocol === 'https:' ? 'wss' : 'ws';
-    const ws = new WebSocket(`${proto}://${location.host}/ws`);
-    this.ws = ws;
-
-    ws.onopen = () => {
-      this.retry = 0;
-      S.connected = true;
-      S.error = null;
-      ws.send(JSON.stringify(this.hello));
-    };
-
-    ws.onmessage = (ev) => {
-      const msg = JSON.parse(ev.data);
-      if (msg.type === 'state') {
-        const prev = S.state?.mark;
-        S.state = msg.state;
-        if (msg.me) S.me = msg.me;
-        if (prev !== undefined && msg.state.mark !== prev) {
-          ui.markFlash = msg.state.mark > prev ? 'flash-up' : 'flash-down';
-          setTimeout(() => { ui.markFlash = null; render(); }, 750);
-        }
-        // Clear the ticket when the round turns over, and only then — every
-        // player action broadcasts, and wiping on each one would erase a
-        // quantity somebody is halfway through typing.
-        const turned = ui.lastRound !== null && ui.lastRound !== msg.state.round;
-        if (turned) {
-          ui.qty = '';
-          ui.cards = { up: 0, down: 0, multiply: 0, add: 0 };
-        }
-        ui.lastRound = msg.state.round;
-        render();
-      } else if (msg.type === 'seated') {
-        store.setPlayerToken(S.code, msg.playerToken);
-      } else if (msg.type === 'die') {
-        ui.rolling = false;
-        render();
-      } else if (msg.type === 'error') {
-        S.error = msg.message;
-        ui.busy = false;
-        ui.rolling = false;
-        render();
-      }
-    };
-
-    ws.onclose = () => {
-      S.connected = false;
-      render();
-      // Back off, but keep trying — a phone that slept should rejoin on its own.
-      this.retry = Math.min(this.retry + 1, 6);
-      setTimeout(() => this.connect(this.hello), 400 * 2 ** (this.retry - 1));
-    };
-
-    ws.onerror = () => ws.close();
+  /** Faster while you owe the table an action, slower once you have acted. */
+  interval() {
+    const st = S.state;
+    if (document.hidden) return 10000;
+    if (!st) return 1200;
+    if (st.phase === 'rolling') return 900;
+    const me = S.me;
+    const owes = st.phase === 'orders' ? !me?.ordersReady
+      : st.phase === 'cards' ? !me?.cardsReady : false;
+    if (S.role !== 'player') return 1200;
+    return owes ? 1500 : 3000;
   },
 
-  send(msg) {
-    if (this.ws?.readyState === WebSocket.OPEN) {
+  start(tok) {
+    this.token = tok ?? this.token;
+    this.stop();
+    this.tick();
+  },
+
+  stop() {
+    clearTimeout(this.timer);
+    this.timer = null;
+  },
+
+  schedule() {
+    clearTimeout(this.timer);
+    this.timer = setTimeout(() => this.tick(), this.interval());
+  },
+
+  async tick() {
+    try {
+      const qs = new URLSearchParams({ code: S.code });
+      if (this.token) qs.set('token', this.token);
+      const res = await fetch(`/api/game?${qs}`, { cache: 'no-store' });
+      const body = await res.json();
+      if (!res.ok) throw new Error(body.error ?? `HTTP ${res.status}`);
+      apply(body);
+      this.failures = 0;
+      S.connected = true;
+    } catch (err) {
+      this.failures++;
+      // One dropped poll is noise; a run of them is worth showing.
+      if (this.failures >= 3) {
+        S.connected = false;
+        render();
+      }
+    }
+    this.schedule();
+  },
+
+  /** Post an action and adopt the state it returns. */
+  async send(action, extra = {}) {
+    try {
       S.error = null;
-      this.ws.send(JSON.stringify(msg));
+      const res = await fetch('/api/game', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action, code: S.code, token: this.token, ...extra }),
+      });
+      const body = await res.json();
+      if (!res.ok) throw new Error(body.error ?? `HTTP ${res.status}`);
+      apply(body);
+      S.connected = true;
+      this.schedule();
+      return body;
+    } catch (err) {
+      S.error = err.message;
+      ui.busy = false;
+      ui.rolling = false;
+      render();
+      return null;
     }
   },
 };
+
+/** Fold a server payload into local state and redraw. */
+function apply(body) {
+  if (body.role) S.role = body.role;
+  if (body.ephemeral !== undefined) S.ephemeral = body.ephemeral;
+
+  const prev = S.state?.mark;
+  S.state = body.state;
+  S.me = body.me ?? null;
+
+  if (prev !== undefined && body.state.mark !== prev) {
+    ui.markFlash = body.state.mark > prev ? 'flash-up' : 'flash-down';
+    setTimeout(() => { ui.markFlash = null; render(); }, 750);
+  }
+
+  // Clear the ticket when the round turns over, and only then — polling redraws
+  // constantly, and wiping on each tick would erase a quantity being typed.
+  if (ui.lastRound !== null && ui.lastRound !== body.state.round) {
+    ui.qty = '';
+    ui.cards = { up: 0, down: 0, multiply: 0, add: 0 };
+  }
+  ui.lastRound = body.state.round;
+
+  ui.rolling = false;
+  render();
+}
 
 // --- Actions ---------------------------------------------------------------
 
@@ -151,20 +196,22 @@ const act = {
   setType(t) { ui.orderType = t; render(); },
   setQty(v) { ui.qty = v.replace(/[^0-9]/g, ''); },
 
-  submitOrder() {
+  async submitOrder() {
     const mag = parseInt(ui.qty || '0', 10);
     if (!Number.isFinite(mag) || mag < 0) { S.error = 'Enter a quantity'; return render(); }
     const qty = ui.side === 'SELL' ? -mag : mag;
-    net.send({ type: 'order', qty, orderType: ui.orderType });
-    net.send({ type: 'confirmOrder' });
+    if (await net.send('order', { qty, orderType: ui.orderType })) {
+      await net.send('confirmOrder');
+    }
   },
 
-  passOrder() {
-    net.send({ type: 'order', qty: 0, orderType: 'LIMIT' });
-    net.send({ type: 'confirmOrder' });
+  async passOrder() {
+    if (await net.send('order', { qty: 0, orderType: 'LIMIT' })) {
+      await net.send('confirmOrder');
+    }
   },
 
-  unconfirmOrder() { net.send({ type: 'unconfirmOrder' }); },
+  unconfirmOrder() { net.send('unconfirmOrder'); },
 
   bumpCard(kind, delta) {
     const held = S.me?.hand?.[kind] ?? 0;
@@ -172,30 +219,31 @@ const act = {
     render();
   },
 
-  submitCards() {
-    net.send({ type: 'cards', cards: ui.cards });
-    net.send({ type: 'confirmCards' });
+  async submitCards() {
+    if (await net.send('cards', { cards: ui.cards })) {
+      await net.send('confirmCards');
+    }
   },
 
-  unconfirmCards() { net.send({ type: 'unconfirmCards' }); },
+  unconfirmCards() { net.send('unconfirmCards'); },
 
   roll() {
     ui.rolling = true;
     render();
-    setTimeout(() => net.send({ type: 'roll' }), 420);   // let the tumble register
+    setTimeout(() => net.send('roll'), 420);   // let the tumble register
   },
 
-  start() { net.send({ type: 'start' }); },
-  force() { net.send({ type: 'force' }); },
+  start() { net.send('start'); },
+  force() { net.send('force'); },
   reset() {
     if (confirm('Reset the game? Every position and hand is wiped. Seats stay.')) {
-      net.send({ type: 'reset' });
+      net.send('reset');
     }
   },
   kick(playerId, name) {
-    if (confirm(`Remove ${name} from the table?`)) net.send({ type: 'kick', playerId });
+    if (confirm(`Remove ${name} from the table?`)) net.send('kick', { playerId });
   },
-  config(patch) { net.send({ type: 'config', config: patch }); },
+  config(patch) { return net.send('config', { config: patch }); },
 
   copy(text, label) {
     navigator.clipboard?.writeText(text).then(() => {
@@ -227,7 +275,15 @@ function topbar(extra = '') {
 }
 
 function alerts() {
+  // On serverless with no Redis, consecutive requests can hit different
+  // instances holding different games. Say so rather than let the table behave
+  // like it is haunted.
+  const ephemeral = S.ephemeral && location.hostname !== 'localhost'
+    ? `<div class="err">No datastore connected — tables will not survive between
+       requests here. Add a Redis integration in the Vercel project settings.</div>`
+    : '';
   return `
+    ${ephemeral}
     ${S.error ? `<div class="err">${esc(S.error)}</div>` : ''}
     ${S.notice ? `<div class="ok">${esc(S.notice)}</div>` : ''}`;
 }
@@ -277,9 +333,7 @@ function waitingPills(st, list) {
   if (!st.standings.length) return '<span class="dim">No players seated</span>';
   return `<div class="waiting">${st.standings.map((p) => {
     const late = list.includes(p.name);
-    const k = !p.connected ? 'gone' : late ? 'late' : 'ready';
-    const mark = !p.connected ? '∅' : late ? '·' : '✓';
-    return `<span class="pill ${k}">${mark} ${esc(p.name)}</span>`;
+    return `<span class="pill ${late ? 'late' : 'ready'}">${late ? '·' : '✓'} ${esc(p.name)}</span>`;
   }).join('')}</div>`;
 }
 
@@ -287,7 +341,7 @@ function standingsTable(st, opts = {}) {
   const rows = st.standings.map((p, i) => `
     <tr class="${opts.meId === p.id ? 'me' : ''}">
       <td class="num dim">${i + 1}</td>
-      <td class="strong">${esc(p.name)}${p.connected ? '' : ' <span class="grey tiny">OFF</span>'}</td>
+      <td class="strong">${esc(p.name)}</td>
       <td class="num ${cls(p.shares)}">${signed(p.shares)}</td>
       <td class="num dim">${p.avgPrice === null ? '—' : px(p.avgPrice)}</td>
       <td class="num strong ${cls(p.pl)}">${money(p.pl)}</td>
@@ -429,11 +483,15 @@ function renderHome() {
   document.getElementById('createBtn').onclick = async () => {
     ui.busy = true; render();
     try {
-      const res = await fetch('/api/games', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}' });
-      if (!res.ok) throw new Error('Could not open a table');
-      const { code: newCode, hostToken } = await res.json();
-      store.setHostToken(newCode, hostToken);
-      location.href = `/${newCode}#host`;
+      const res = await fetch('/api/game', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'create' }),
+      });
+      const body = await res.json();
+      if (!res.ok) throw new Error(body.error ?? 'Could not open a table');
+      store.setHostToken(body.code, body.hostToken);
+      location.href = `/${body.code}#host`;
     } catch (err) {
       S.error = err.message;
       ui.busy = false;
@@ -474,11 +532,12 @@ function renderJoin() {
   input.onkeydown = (e) => { if (e.key === 'Enter') sit(); };
   input.focus();
 
-  const sit = () => {
+  const sit = async () => {
     if (!ui.name.trim()) { S.error = 'Name required'; return render(); }
-    net.connect({ role: 'player', code: S.code, name: ui.name.trim() });
-    S.role = 'player';
-    render();
+    const res = await net.send('join', { name: ui.name.trim() });
+    if (!res) return;
+    store.setPlayerToken(S.code, res.playerToken);
+    net.start(res.playerToken);
   };
   document.getElementById('sit').onclick = sit;
 }
@@ -988,36 +1047,43 @@ function route() {
 
   S.code = path;
 
+  // The token alone tells the server who you are; the hash only decides which
+  // screen this device wants when it holds no seat.
   if (hash === 'host') {
     const t = store.hostToken(path);
     if (!t) {
-      S.error = 'No host credentials for this table on this device. Open it from the machine that created it, or run the dashboard instead.';
+      S.error = 'No host credentials for this table on this device. Open it from the machine that created it, or use the dashboard instead.';
       S.role = 'dashboard';
-      net.connect({ role: 'dashboard', code: path });
+      net.start(null);
       return render();
     }
     S.role = 'host';
-    net.connect({ role: 'host', code: path, hostToken: t });
+    net.start(t);
     return render();
   }
 
   if (hash === 'dashboard') {
     S.role = 'dashboard';
-    net.connect({ role: 'dashboard', code: path });
+    net.start(null);
     return render();
   }
 
-  // Player: reconnect silently if this device already has a seat.
-  const token = store.playerToken(path);
-  if (token) {
+  // Player: rejoin silently if this device already holds a seat.
+  const seat = store.playerToken(path);
+  if (seat) {
     S.role = 'player';
-    net.connect({ role: 'player', code: path, playerToken: token });
+    net.start(seat);
     return render();
   }
 
   S.role = null;   // prompt for a name
   render();
 }
+
+// Polling pauses on a hidden tab; catch up the moment it comes back.
+document.addEventListener('visibilitychange', () => {
+  if (!document.hidden && S.code && net.timer) net.start();
+});
 
 window.addEventListener('hashchange', () => location.reload());
 route();

--- a/mooncoin/public/app.js
+++ b/mooncoin/public/app.js
@@ -535,8 +535,8 @@ function orderTicket(st, me) {
       </div>
       <p class="dim tiny" style="margin:0 0 8px">
         ${ui.orderType === 'MARKET'
-          ? 'Market fills for certain and pays √imbalance in impact.'
-          : 'Limit rests. It moves nothing and only trades if market flow comes the other way.'}
+          ? 'Market fills for certain and pays √imbalance in impact — less whatever the resting book absorbs.'
+          : 'Limit rests at last sale. It soaks up pressure coming the other way and fills at the clearing price, or does not fill at all.'}
       </p>
       <div class="split">
         <button id="pass">Pass</button>
@@ -776,6 +776,7 @@ function renderDashboard(hostMode = false) {
   const book = st.reveal ?? (last ? {
     limitBid: last.limitBid, marketBid: last.marketBid, imbalance: last.imbalance,
     marketOffer: last.marketOffer, limitOffer: last.limitOffer,
+    pressure: last.pressure, absorbed: last.absorbed,
     price: last.print, houseResidual: last.houseResidual,
   } : null);
   const bookRound = liveBook ? st.round : last?.round;
@@ -856,9 +857,11 @@ function renderDashboard(hostMode = false) {
                 : 'sealed until the gate trips'}</span>
             </header>
             ${ladder(book)}
-            ${book?.houseResidual > 0
-              ? `<div class="body dim tiny">House absorbed ${book.houseResidual} — resting book could not cover the market flow</div>`
-              : ''}
+            ${book ? `<div class="body dim tiny">
+              Pressure ${signed(book.pressure ?? 0)} · book absorbed ${book.absorbed ?? 0} ·
+              imbalance ${signed(book.imbalance)} · slippage ${signed(impactOf(book.imbalance))}
+              ${book.houseResidual > 0 ? `· house left holding ${book.houseResidual}` : '· fully matched'}
+            </div>` : ''}
           </div>
 
           ${dice ? `

--- a/mooncoin/public/index.html
+++ b/mooncoin/public/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <meta name="theme-color" content="#000000">
+  <meta name="description" content="Mooncoin — a multiplayer market game with square-root price impact.">
+  <title>MOONCOIN TERMINAL</title>
+  <link rel="stylesheet" href="/style.css">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect width='32' height='32' fill='%23000'/><text y='24' x='16' text-anchor='middle' font-size='22' fill='%23ffa028'>%E2%97%90</text></svg>">
+</head>
+<body>
+  <div id="app"></div>
+  <script type="module" src="/app.js"></script>
+</body>
+</html>

--- a/mooncoin/public/style.css
+++ b/mooncoin/public/style.css
@@ -1,0 +1,384 @@
+/* ===========================================================================
+   MOONCOIN TERMINAL
+   Amber phosphor on black. Dense grids, hard edges, tabular figures.
+   No rounded corners, no shadows, no gradients — a trading terminal, not an app.
+   =========================================================================== */
+
+:root {
+  --bg: #000000;
+  --bg-panel: #0a0a0a;
+  --bg-row: #121212;
+  --bg-row-alt: #0d0d0d;
+
+  --amber: #ffa028;
+  --amber-dim: #b36f14;
+  --amber-deep: #7a4b0c;
+  --amber-glow: rgba(255, 160, 40, 0.14);
+
+  --up: #2bd96b;
+  --down: #ff4a3d;
+  --cyan: #4bc8ff;
+  --white: #e8e8e8;
+  --grey: #6d6d6d;
+  --grey-dark: #333333;
+
+  --rule: #3a2a12;
+  --rule-bright: #6b4d1c;
+
+  --mono: "IBM Plex Mono", "SFMono-Regular", "SF Mono", Menlo, Consolas,
+          "DejaVu Sans Mono", monospace;
+
+  --gap: 6px;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  background: var(--bg);
+  color: var(--amber);
+  font-family: var(--mono);
+  font-size: 13px;
+  line-height: 1.35;
+  font-variant-numeric: tabular-nums;
+  -webkit-font-smoothing: antialiased;
+}
+
+body { overflow-x: hidden; }
+
+#app { min-height: 100%; display: flex; flex-direction: column; }
+
+/* --- Type ---------------------------------------------------------------- */
+
+h1, h2, h3 { margin: 0; font-weight: 700; letter-spacing: 0.08em; }
+h1 { font-size: 15px; }
+h2 { font-size: 12px; }
+a { color: var(--cyan); }
+
+.dim   { color: var(--amber-dim); }
+.grey  { color: var(--grey); }
+.white { color: var(--white); }
+.up    { color: var(--up); }
+.down  { color: var(--down); }
+.cyan  { color: var(--cyan); }
+.num   { font-variant-numeric: tabular-nums; text-align: right; }
+.center{ text-align: center; }
+.big   { font-size: 28px; font-weight: 700; letter-spacing: 0.02em; }
+.huge  { font-size: 44px; font-weight: 700; letter-spacing: -0.01em; }
+.tiny  { font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; }
+.strong{ font-weight: 700; }
+
+/* --- Top bar ------------------------------------------------------------- */
+
+.topbar {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  background: var(--amber);
+  color: #000;
+  padding: 4px 10px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  font-size: 12px;
+  text-transform: uppercase;
+  flex-wrap: wrap;
+}
+.topbar .spacer { margin-left: auto; }
+.topbar .chip {
+  background: #000;
+  color: var(--amber);
+  padding: 1px 7px;
+  letter-spacing: 0.14em;
+}
+.topbar .chip.live { background: #000; color: var(--up); }
+.topbar .chip.off  { background: #000; color: var(--down); }
+
+/* --- Layout -------------------------------------------------------------- */
+
+.wrap  { padding: var(--gap); display: flex; flex-direction: column; gap: var(--gap); flex: 1; }
+.cols  { display: grid; gap: var(--gap); grid-template-columns: 1fr 1fr; align-items: start; }
+.cols3 { display: grid; gap: var(--gap); grid-template-columns: 1fr 1fr 1fr; align-items: start; }
+.cols-2-1 { display: grid; gap: var(--gap); grid-template-columns: 2fr 1fr; align-items: start; }
+
+@media (max-width: 900px) {
+  .cols, .cols3, .cols-2-1 { grid-template-columns: 1fr; }
+}
+
+/* --- Panels -------------------------------------------------------------- */
+
+.panel {
+  border: 1px solid var(--rule);
+  background: var(--bg-panel);
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+.panel > header {
+  background: var(--amber);
+  color: #000;
+  padding: 2px 8px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.panel > header .spacer { margin-left: auto; }
+.panel > header .note { font-weight: 400; letter-spacing: 0.06em; opacity: 0.75; }
+.panel .body { padding: 8px; }
+.panel .body.flush { padding: 0; }
+
+.panel.ghost > header { background: var(--amber-deep); color: #000; }
+
+/* --- Tables -------------------------------------------------------------- */
+
+table { width: 100%; border-collapse: collapse; font-size: 12px; }
+th {
+  text-align: left;
+  font-weight: 700;
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--amber-dim);
+  border-bottom: 1px solid var(--rule);
+  padding: 3px 8px;
+  white-space: nowrap;
+}
+td {
+  padding: 3px 8px;
+  border-bottom: 1px solid #1a1a1a;
+  white-space: nowrap;
+}
+tbody tr:nth-child(odd) { background: var(--bg-row-alt); }
+tbody tr.me { background: var(--amber-glow); }
+tbody tr.me td:first-child { box-shadow: inset 2px 0 0 var(--amber); }
+th.num, td.num { text-align: right; }
+.scroll-x { overflow-x: auto; }
+
+/* --- Controls ------------------------------------------------------------ */
+
+button, .btn {
+  font-family: var(--mono);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  background: #000;
+  color: var(--amber);
+  border: 1px solid var(--amber-dim);
+  padding: 6px 12px;
+  cursor: pointer;
+  transition: background 60ms linear, color 60ms linear;
+}
+button:hover:not(:disabled) { background: var(--amber); color: #000; }
+button:active:not(:disabled) { background: var(--amber-dim); }
+button:disabled { color: var(--grey-dark); border-color: var(--grey-dark); cursor: not-allowed; }
+
+button.primary { background: var(--amber); color: #000; border-color: var(--amber); }
+button.primary:hover:not(:disabled) { background: #ffb750; }
+button.danger { color: var(--down); border-color: var(--down); }
+button.danger:hover:not(:disabled) { background: var(--down); color: #000; }
+button.buy  { color: var(--up); border-color: var(--up); }
+button.buy:hover:not(:disabled), button.buy.on { background: var(--up); color: #000; }
+button.sell { color: var(--down); border-color: var(--down); }
+button.sell:hover:not(:disabled), button.sell.on { background: var(--down); color: #000; }
+button.on { background: var(--amber); color: #000; }
+button.wide { width: 100%; }
+button.lg { font-size: 15px; padding: 12px 18px; }
+
+input, select {
+  font-family: var(--mono);
+  font-size: 14px;
+  background: #000;
+  color: var(--amber);
+  border: 1px solid var(--amber-dim);
+  padding: 6px 8px;
+  width: 100%;
+}
+input:focus, select:focus { outline: none; border-color: var(--amber); background: #0d0900; }
+input::placeholder { color: var(--grey-dark); }
+input:disabled, select:disabled { color: var(--grey); border-color: var(--grey-dark); }
+input.num { text-align: right; font-size: 20px; font-weight: 700; }
+
+label.field { display: block; margin-bottom: 8px; }
+label.field > span {
+  display: block;
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--amber-dim);
+  margin-bottom: 3px;
+}
+
+.row { display: flex; gap: var(--gap); align-items: center; flex-wrap: wrap; }
+.row.tight { gap: 4px; }
+.stack { display: flex; flex-direction: column; gap: var(--gap); }
+.split { display: grid; grid-template-columns: 1fr 1fr; gap: var(--gap); }
+
+/* --- Readouts ------------------------------------------------------------ */
+
+.readout { display: flex; flex-direction: column; gap: 1px; padding: 6px 8px; }
+.readout .label {
+  font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--amber-dim);
+}
+.readout .value { font-size: 22px; font-weight: 700; line-height: 1.1; }
+
+.tiles { display: grid; grid-template-columns: repeat(auto-fit, minmax(110px, 1fr)); }
+.tiles .readout { border-right: 1px solid var(--rule); }
+.tiles .readout:last-child { border-right: none; }
+
+/* Price flash on a new print */
+@keyframes flash-up   { from { background: rgba(43, 217, 107, 0.35); } to { background: transparent; } }
+@keyframes flash-down { from { background: rgba(255, 74, 61, 0.35); }  to { background: transparent; } }
+.flash-up   { animation: flash-up 700ms ease-out; }
+.flash-down { animation: flash-down 700ms ease-out; }
+
+/* --- The ladder ---------------------------------------------------------- */
+
+.ladder { display: grid; grid-template-columns: repeat(5, 1fr); text-align: center; }
+.ladder > div { border-right: 1px solid var(--rule); padding: 8px 4px; }
+.ladder > div:last-child { border-right: none; }
+.ladder .label {
+  font-size: 9px; letter-spacing: 0.12em; text-transform: uppercase;
+  color: var(--amber-dim); margin-bottom: 4px;
+}
+.ladder .qty { font-size: 24px; font-weight: 700; }
+.ladder .bid  .qty { color: var(--up); }
+.ladder .offer .qty { color: var(--down); }
+.ladder .imb { background: #14100a; }
+.ladder .imb .qty { font-size: 28px; }
+
+/* --- Dice ---------------------------------------------------------------- */
+
+.dice { display: grid; grid-template-columns: repeat(4, 1fr); gap: var(--gap); }
+.die {
+  border: 1px solid var(--rule);
+  background: #000;
+  padding: 10px 4px;
+  text-align: center;
+  min-height: 96px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+}
+.die .cap {
+  font-size: 9px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--amber-dim);
+}
+.die .pip { font-size: 40px; font-weight: 700; line-height: 1; }
+.die.locked { border-color: var(--amber); }
+.die.locked .pip { color: var(--amber); }
+.die.empty .pip { color: var(--grey-dark); }
+.die.next { border-color: var(--amber); background: #140d02; }
+.die.rolling .pip { animation: tumble 90ms steps(1) infinite; }
+
+@keyframes tumble {
+  0%   { opacity: 1; transform: translateY(0); }
+  50%  { opacity: 0.35; transform: translateY(-3px); }
+  100% { opacity: 1; transform: translateY(0); }
+}
+
+/* --- Cards --------------------------------------------------------------- */
+
+.cardgrid { display: grid; grid-template-columns: repeat(4, 1fr); gap: var(--gap); }
+.card {
+  border: 1px solid var(--rule);
+  background: #000;
+  padding: 8px 6px;
+  text-align: center;
+}
+.card.spent { opacity: 0.35; }
+.card .glyph { font-size: 26px; font-weight: 700; line-height: 1.1; }
+.card .name  { font-size: 9px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--amber-dim); }
+.card .held  { font-size: 11px; color: var(--white); margin-top: 2px; }
+.card.up   .glyph { color: var(--up); }
+.card.down .glyph { color: var(--down); }
+.card.multiply .glyph, .card.add .glyph { color: var(--cyan); }
+.card .stepper { display: flex; gap: 2px; margin-top: 5px; }
+.card .stepper button { flex: 1; padding: 3px 0; font-size: 13px; letter-spacing: 0; }
+.card .picked { font-size: 18px; font-weight: 700; min-width: 22px; text-align: center; padding-top: 2px; }
+
+/* --- Status strip -------------------------------------------------------- */
+
+.waiting { display: flex; gap: 4px; flex-wrap: wrap; }
+.pill {
+  border: 1px solid var(--rule-bright);
+  padding: 1px 7px;
+  font-size: 11px;
+  letter-spacing: 0.06em;
+}
+.pill.ready { border-color: var(--up); color: var(--up); }
+.pill.late  { border-color: var(--amber-dim); color: var(--amber-dim); }
+.pill.gone  { border-color: var(--grey-dark); color: var(--grey-dark); text-decoration: line-through; }
+
+.tape {
+  font-size: 11px;
+  color: var(--amber-dim);
+  max-height: 150px;
+  overflow-y: auto;
+  padding: 6px 8px;
+}
+.tape div { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.tape .t { color: var(--grey); margin-right: 6px; }
+
+/* --- Home / join --------------------------------------------------------- */
+
+.home {
+  max-width: 460px;
+  margin: 0 auto;
+  padding: 40px 16px;
+  width: 100%;
+}
+.brand { text-align: center; margin-bottom: 26px; }
+.brand .logo { font-size: 30px; font-weight: 700; letter-spacing: 0.3em; }
+.brand .sub  { font-size: 10px; letter-spacing: 0.32em; color: var(--amber-dim); margin-top: 4px; }
+.brand .rule { border-top: 1px solid var(--rule); margin-top: 14px; }
+
+.code-in { font-size: 34px; text-align: center; letter-spacing: 0.34em; text-transform: uppercase; }
+
+.err {
+  border: 1px solid var(--down);
+  color: var(--down);
+  padding: 6px 8px;
+  font-size: 12px;
+}
+.ok {
+  border: 1px solid var(--up);
+  color: var(--up);
+  padding: 6px 8px;
+  font-size: 12px;
+}
+
+.blink::after {
+  content: "\2588";
+  animation: blink 1s steps(1) infinite;
+  margin-left: 2px;
+}
+@keyframes blink { 50% { opacity: 0; } }
+
+.banner {
+  background: var(--amber);
+  color: #000;
+  text-align: center;
+  padding: 8px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+.banner.wait { background: #000; color: var(--amber-dim); border: 1px solid var(--rule); }
+
+/* Dashboard runs on a projector — scale it up and keep it readable at range. */
+.dashboard { font-size: 15px; }
+.dashboard table { font-size: 15px; }
+.dashboard th { font-size: 11px; }
+.dashboard .readout .value { font-size: 30px; }
+.dashboard .ladder .qty { font-size: 34px; }
+.dashboard .ladder .imb .qty { font-size: 40px; }
+.dashboard .die { min-height: 128px; }
+.dashboard .die .pip { font-size: 56px; }
+
+@media print { body { background: #fff; color: #000; } }

--- a/mooncoin/server/e2e.test.js
+++ b/mooncoin/server/e2e.test.js
@@ -131,10 +131,13 @@ test('a full game runs over websockets', async () => {
   bob.send({ type: 'confirmOrder' });
   await waitFor(() => alice.state?.phase === 'cards', 'orders gate to trip');
 
-  assert.equal(alice.state.reveal.price, 102);       // 100 + ceil(sqrt(4))
-  assert.equal(alice.state.reveal.imbalance, 4);
+  // Bob's resting offer covers Alice's demand exactly, so the print is flat.
+  assert.equal(alice.state.reveal.absorbed, 4);
+  assert.equal(alice.state.reveal.imbalance, 0);
+  assert.equal(alice.state.reveal.price, 100);
+  assert.equal(alice.state.reveal.houseResidual, 0);
   await waitFor(() => alice.me?.fills.length === 1, 'blotter written by the engine');
-  assert.equal(alice.me.fills[0].price, 102);
+  assert.equal(alice.me.fills[0].price, 100);
   assert.equal(alice.me.fills[0].qty, 4);
 
   // Cards

--- a/mooncoin/server/e2e.test.js
+++ b/mooncoin/server/e2e.test.js
@@ -1,0 +1,278 @@
+/**
+ * End-to-end: a real HTTP + WebSocket server, real sockets, a full game played
+ * through the same message protocol the browser uses.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { join, dirname } from 'node:path';
+import { rmSync } from 'node:fs';
+import WebSocket from 'ws';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PORT = 3199;
+const BASE = `http://127.0.0.1:${PORT}`;
+const DATA = join(HERE, '..', '.data', 'e2e-test.json');
+
+let proc;
+
+function waitFor(predicate, what, timeout = 5000) {
+  return new Promise((resolve, reject) => {
+    const started = Date.now();
+    const tick = async () => {
+      // Must await: an async predicate returns a Promise, which is always
+      // truthy, and would otherwise resolve the wait on the first tick.
+      let v;
+      try { v = await predicate(); } catch { v = false; }
+      if (v) return resolve(v);
+      if (Date.now() - started > timeout) return reject(new Error(`Timed out waiting for ${what}`));
+      setTimeout(tick, 15);
+    };
+    tick();
+  });
+}
+
+/** A test client that records every state push. */
+function client(hello) {
+  const c = {
+    ws: new WebSocket(`ws://127.0.0.1:${PORT}/ws`),
+    state: null, me: null, errors: [], seated: null,
+    send(m) { c.ws.send(JSON.stringify(m)); },
+    close() { c.ws.close(); },
+  };
+  c.ws.on('open', () => c.send({ type: 'hello', ...hello }));
+  c.ws.on('message', (raw) => {
+    const m = JSON.parse(raw);
+    if (m.type === 'state') { c.state = m.state; if (m.me) c.me = m.me; }
+    else if (m.type === 'seated') c.seated = m;
+    else if (m.type === 'error') c.errors.push(m.message);
+  });
+  return c;
+}
+
+test.before(async () => {
+  rmSync(DATA, { force: true });
+  proc = spawn(process.execPath, [join(HERE, 'index.js')], {
+    env: { ...process.env, PORT: String(PORT), MOONCOIN_DATA: DATA },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  proc.stderr.on('data', (d) => process.stderr.write(`[server] ${d}`));
+
+  await waitFor(async () => {
+    try { return (await fetch(`${BASE}/api/games/ZZZZ`)).status === 404; }
+    catch { return false; }
+  }, 'server to boot');
+});
+
+test.after(() => {
+  proc?.kill('SIGKILL');
+  rmSync(DATA, { force: true });
+});
+
+// ---------------------------------------------------------------------------
+
+test('serves the app shell on a room path', async () => {
+  const res = await fetch(`${BASE}/ABCD`);
+  assert.equal(res.status, 200);
+  assert.match(await res.text(), /MOONCOIN TERMINAL/);
+});
+
+test('static assets are served', async () => {
+  assert.equal((await fetch(`${BASE}/style.css`)).status, 200);
+  assert.equal((await fetch(`${BASE}/app.js`)).status, 200);
+});
+
+test('directory traversal is refused', async () => {
+  const res = await fetch(`${BASE}/../package.json`);
+  const body = await res.text();
+  assert.ok(!body.includes('"dependencies"'), 'must not serve files above public/');
+});
+
+test('a full game runs over websockets', async () => {
+  const created = await fetch(`${BASE}/api/games`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ maxRounds: 2, cardQty: 6 }),
+  });
+  assert.equal(created.status, 201);
+  const { code, hostToken } = await created.json();
+  assert.match(code, /^[A-Z0-9]{4}$/);
+
+  const host = client({ role: 'host', code, hostToken });
+  const dash = client({ role: 'dashboard', code });
+  const alice = client({ role: 'player', code, name: 'alice' });
+  const bob = client({ role: 'player', code, name: 'bob' });
+
+  await waitFor(() => host.state?.seated === 2 && alice.me && bob.me, 'both players seated');
+  assert.equal(alice.me.name, 'ALICE');
+  assert.ok(alice.seated.playerToken, 'player gets a reconnect token');
+
+  // Dashboards never receive a hand.
+  assert.equal(dash.me, null);
+
+  host.send({ type: 'start' });
+  await waitFor(() => alice.state?.phase === 'orders', 'market to open');
+  assert.equal(alice.me.hand.up + alice.me.hand.down + alice.me.hand.multiply + alice.me.hand.add, 6);
+
+  // Round 1 — alice lifts 4 at market, bob rests 4 offered.
+  alice.send({ type: 'order', qty: 4, orderType: 'MARKET' });
+  alice.send({ type: 'confirmOrder' });
+  await waitFor(() => alice.me?.ordersReady, 'alice confirmed');
+  assert.equal(alice.state.phase, 'orders', 'gate holds for bob');
+  assert.deepEqual(alice.state.awaitingOrders, ['BOB']);
+
+  // Nothing about alice's size may be visible to bob before the gate trips.
+  assert.equal(bob.state.reveal, null);
+  assert.ok(!JSON.stringify(bob.state).includes('"qty":4'));
+
+  bob.send({ type: 'order', qty: -4, orderType: 'LIMIT' });
+  bob.send({ type: 'confirmOrder' });
+  await waitFor(() => alice.state?.phase === 'cards', 'orders gate to trip');
+
+  assert.equal(alice.state.reveal.price, 102);       // 100 + ceil(sqrt(4))
+  assert.equal(alice.state.reveal.imbalance, 4);
+  await waitFor(() => alice.me?.fills.length === 1, 'blotter written by the engine');
+  assert.equal(alice.me.fills[0].price, 102);
+  assert.equal(alice.me.fills[0].qty, 4);
+
+  // Cards
+  alice.send({ type: 'confirmCards' });
+  bob.send({ type: 'confirmCards' });
+  await waitFor(() => alice.state?.phase === 'rolling', 'cards gate to trip');
+  assert.ok(dash.state.net, 'dashboard sees the reveal');
+
+  for (let i = 0; i < 4; i++) {
+    const before = host.state.rollStep;
+    host.send({ type: 'roll' });
+    await waitFor(() => host.state.rollStep !== before || host.state.round === 2, `die ${i + 1}`);
+  }
+
+  await waitFor(() => alice.state?.round === 2, 'round to advance');
+  assert.equal(alice.state.history.length, 1);
+  assert.equal(alice.state.mark, alice.state.history[0].mark);
+
+  // Round 2 — both pass, then roll it out.
+  for (const c of [alice, bob]) {
+    c.send({ type: 'order', qty: 0, orderType: 'LIMIT' });
+    c.send({ type: 'confirmOrder' });
+  }
+  await waitFor(() => alice.state?.phase === 'cards', 'second orders gate');
+  alice.send({ type: 'confirmCards' });
+  bob.send({ type: 'confirmCards' });
+  await waitFor(() => alice.state?.phase === 'rolling', 'second cards gate');
+
+  for (let i = 0; i < 4; i++) {
+    const before = host.state.rollStep;
+    host.send({ type: 'roll' });
+    await waitFor(() => host.state.rollStep !== before || host.state.phase === 'complete', `r2 die ${i + 1}`);
+  }
+
+  await waitFor(() => alice.state?.phase === 'complete', 'game to close');
+
+  // P/L is zero-sum between the two of them: same fill, opposite sides.
+  const s = alice.state.standings;
+  assert.equal(s.reduce((a, p) => a + p.pl, 0), 0);
+
+  [host, dash, alice, bob].forEach((c) => c.close());
+});
+
+test('a player reconnects to the same seat and blotter', async () => {
+  const { code, hostToken } = await (await fetch(`${BASE}/api/games`, {
+    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ maxRounds: 1, cardQty: 4 }),
+  })).json();
+
+  const host = client({ role: 'host', code, hostToken });
+  let carol = client({ role: 'player', code, name: 'carol' });
+  const dave = client({ role: 'player', code, name: 'dave' });
+
+  await waitFor(() => host.state?.seated === 2 && carol.seated, 'seated');
+  const token = carol.seated.playerToken;
+
+  host.send({ type: 'start' });
+  await waitFor(() => carol.state?.phase === 'orders', 'open');
+
+  carol.send({ type: 'order', qty: 9, orderType: 'MARKET' });
+  carol.send({ type: 'confirmOrder' });
+  dave.send({ type: 'order', qty: 0, orderType: 'LIMIT' });
+  dave.send({ type: 'confirmOrder' });
+  await waitFor(() => carol.me?.fills.length === 1, 'filled');
+  const fills = JSON.stringify(carol.me.fills);
+
+  // Phone sleeps.
+  carol.close();
+  await waitFor(() => host.state.standings.find((p) => p.name === 'CAROL')?.connected === false,
+    'server to notice the drop');
+
+  carol = client({ role: 'player', code, playerToken: token });
+  await waitFor(() => carol.me, 'reconnect');
+
+  assert.equal(carol.me.name, 'CAROL');
+  assert.equal(carol.me.seat, 1);
+  assert.equal(JSON.stringify(carol.me.fills), fills, 'blotter survived the drop');
+
+  [host, carol, dave].forEach((c) => c.close());
+});
+
+test('host controls are refused without the token', async () => {
+  const { code } = await (await fetch(`${BASE}/api/games`, {
+    method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}',
+  })).json();
+
+  const imposter = client({ role: 'host', code, hostToken: 'not-the-token' });
+  await waitFor(() => imposter.errors.length, 'rejection');
+  assert.match(imposter.errors[0], /Bad host token/);
+
+  // A dashboard cannot drive the game either.
+  const dash = client({ role: 'dashboard', code });
+  await waitFor(() => dash.state, 'dashboard connected');
+  dash.send({ type: 'start' });
+  await waitFor(() => dash.errors.length, 'refusal');
+  assert.match(dash.errors[0], /Host controls only/);
+
+  [imposter, dash].forEach((c) => c.close());
+});
+
+test('joining an unknown table fails cleanly', async () => {
+  const c = client({ role: 'player', code: 'ZZZZ', name: 'nobody' });
+  await waitFor(() => c.errors.length, 'error');
+  assert.match(c.errors[0], /No table with code/);
+  c.close();
+});
+
+test('games survive a server restart', async () => {
+  const { code, hostToken } = await (await fetch(`${BASE}/api/games`, {
+    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ maxRounds: 3, cardQty: 5 }),
+  })).json();
+
+  let host = client({ role: 'host', code, hostToken });
+  const erin = client({ role: 'player', code, name: 'erin' });
+  await waitFor(() => host.state?.seated === 1, 'seated');
+  host.send({ type: 'start' });
+  await waitFor(() => erin.state?.phase === 'orders', 'open');
+  const token = erin.seated.playerToken;
+  host.close(); erin.close();
+
+  // Let the debounced snapshot land, then bounce the process.
+  await new Promise((r) => setTimeout(r, 400));
+  proc.kill('SIGKILL');
+  await new Promise((r) => setTimeout(r, 150));
+
+  proc = spawn(process.execPath, [join(HERE, 'index.js')], {
+    env: { ...process.env, PORT: String(PORT), MOONCOIN_DATA: DATA },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  await waitFor(async () => {
+    try { return (await fetch(`${BASE}/api/games/${code}`)).status === 200; }
+    catch { return false; }
+  }, 'server to come back with the game');
+
+  const back = client({ role: 'player', code, playerToken: token });
+  await waitFor(() => back.me, 'rejoin after restart');
+  assert.equal(back.me.name, 'ERIN');
+  assert.equal(back.state.phase, 'orders', 'mid-round state preserved');
+  back.close();
+});

--- a/mooncoin/server/e2e.test.js
+++ b/mooncoin/server/e2e.test.js
@@ -1,6 +1,6 @@
 /**
- * End-to-end: a real HTTP + WebSocket server, real sockets, a full game played
- * through the same message protocol the browser uses.
+ * End-to-end: a real HTTP server, a full game played through the same requests
+ * the browser makes.
  */
 
 import test from 'node:test';
@@ -8,13 +8,10 @@ import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { join, dirname } from 'node:path';
-import { rmSync } from 'node:fs';
-import WebSocket from 'ws';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const PORT = 3199;
 const BASE = `http://127.0.0.1:${PORT}`;
-const DATA = join(HERE, '..', '.data', 'e2e-test.json');
 
 let proc;
 
@@ -34,44 +31,41 @@ function waitFor(predicate, what, timeout = 5000) {
   });
 }
 
-/** A test client that records every state push. */
-function client(hello) {
-  const c = {
-    ws: new WebSocket(`ws://127.0.0.1:${PORT}/ws`),
-    state: null, me: null, errors: [], seated: null,
-    send(m) { c.ws.send(JSON.stringify(m)); },
-    close() { c.ws.close(); },
-  };
-  c.ws.on('open', () => c.send({ type: 'hello', ...hello }));
-  c.ws.on('message', (raw) => {
-    const m = JSON.parse(raw);
-    if (m.type === 'state') { c.state = m.state; if (m.me) c.me = m.me; }
-    else if (m.type === 'seated') c.seated = m;
-    else if (m.type === 'error') c.errors.push(m.message);
+async function post(body) {
+  const res = await fetch(`${BASE}/api/game`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
   });
-  return c;
+  return { status: res.status, body: await res.json() };
 }
 
+async function get(code, token) {
+  const qs = new URLSearchParams({ code });
+  if (token) qs.set('token', token);
+  const res = await fetch(`${BASE}/api/game?${qs}`);
+  return { status: res.status, body: await res.json() };
+}
+
+const newTable = async (config) => (await post({ action: 'create', config })).body;
+const sit = async (code, name) => (await post({ action: 'join', code, name })).body;
+const act = (code, token, action, extra = {}) => post({ action, code, token, ...extra });
+
 test.before(async () => {
-  rmSync(DATA, { force: true });
   proc = spawn(process.execPath, [join(HERE, 'index.js')], {
-    env: { ...process.env, PORT: String(PORT), MOONCOIN_DATA: DATA },
+    env: { ...process.env, PORT: String(PORT) },
     stdio: ['ignore', 'pipe', 'pipe'],
   });
   proc.stderr.on('data', (d) => process.stderr.write(`[server] ${d}`));
-
   await waitFor(async () => {
-    try { return (await fetch(`${BASE}/api/games/ZZZZ`)).status === 404; }
+    try { return (await fetch(`${BASE}/api/game?code=ZZZZ`)).status === 404; }
     catch { return false; }
   }, 'server to boot');
 });
 
-test.after(() => {
-  proc?.kill('SIGKILL');
-  rmSync(DATA, { force: true });
-});
+test.after(() => proc?.kill('SIGKILL'));
 
-// ---------------------------------------------------------------------------
+// --- Static ---------------------------------------------------------------
 
 test('serves the app shell on a room path', async () => {
   const res = await fetch(`${BASE}/ABCD`);
@@ -85,197 +79,183 @@ test('static assets are served', async () => {
 });
 
 test('directory traversal is refused', async () => {
-  const res = await fetch(`${BASE}/../package.json`);
-  const body = await res.text();
-  assert.ok(!body.includes('"dependencies"'), 'must not serve files above public/');
+  const body = await (await fetch(`${BASE}/../package.json`)).text();
+  assert.ok(!body.includes('"scripts"'), 'must not serve files above public/');
 });
 
-test('a full game runs over websockets', async () => {
-  const created = await fetch(`${BASE}/api/games`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ maxRounds: 2, cardQty: 6 }),
-  });
-  assert.equal(created.status, 201);
-  const { code, hostToken } = await created.json();
+test('polled state is never cached', async () => {
+  const { code } = await newTable();
+  const res = await fetch(`${BASE}/api/game?code=${code}`);
+  assert.match(res.headers.get('cache-control'), /no-store/);
+});
+
+// --- A whole game ---------------------------------------------------------
+
+test('a full game runs over HTTP', async () => {
+  const { code, hostToken } = await newTable({ maxRounds: 2, cardQty: 6 });
   assert.match(code, /^[A-Z0-9]{4}$/);
 
-  const host = client({ role: 'host', code, hostToken });
-  const dash = client({ role: 'dashboard', code });
-  const alice = client({ role: 'player', code, name: 'alice' });
-  const bob = client({ role: 'player', code, name: 'bob' });
-
-  await waitFor(() => host.state?.seated === 2 && alice.me && bob.me, 'both players seated');
+  const alice = await sit(code, 'alice');
+  const bob = await sit(code, 'bob');
   assert.equal(alice.me.name, 'ALICE');
-  assert.ok(alice.seated.playerToken, 'player gets a reconnect token');
+  assert.ok(alice.playerToken);
+  assert.equal(bob.state.seated, 2);
 
-  // Dashboards never receive a hand.
-  assert.equal(dash.me, null);
+  // A tokenless poll is a dashboard, and gets no hand.
+  const dash = await get(code);
+  assert.equal(dash.body.role, 'dashboard');
+  assert.equal(dash.body.me, undefined);
 
-  host.send({ type: 'start' });
-  await waitFor(() => alice.state?.phase === 'orders', 'market to open');
-  assert.equal(alice.me.hand.up + alice.me.hand.down + alice.me.hand.multiply + alice.me.hand.add, 6);
+  // Roles come from the token, not from asking nicely.
+  assert.equal((await get(code, hostToken)).body.role, 'host');
+  assert.equal((await get(code, alice.playerToken)).body.role, 'player');
 
-  // Round 1 — alice lifts 4 at market, bob rests 4 offered.
-  alice.send({ type: 'order', qty: 4, orderType: 'MARKET' });
-  alice.send({ type: 'confirmOrder' });
-  await waitFor(() => alice.me?.ordersReady, 'alice confirmed');
-  assert.equal(alice.state.phase, 'orders', 'gate holds for bob');
-  assert.deepEqual(alice.state.awaitingOrders, ['BOB']);
+  await act(code, hostToken, 'start');
+  const opened = await get(code, alice.playerToken);
+  assert.equal(opened.body.state.phase, 'orders');
+  const hand = opened.body.me.hand;
+  assert.equal(hand.up + hand.down + hand.multiply + hand.add, 6);
 
-  // Nothing about alice's size may be visible to bob before the gate trips.
-  assert.equal(bob.state.reveal, null);
-  assert.ok(!JSON.stringify(bob.state).includes('"qty":4'));
+  // Round 1 — alice takes 4 at market, bob rests 4 offered.
+  await act(code, alice.playerToken, 'order', { qty: 4, orderType: 'MARKET' });
+  const afterAlice = await act(code, alice.playerToken, 'confirmOrder');
+  assert.equal(afterAlice.body.state.phase, 'orders', 'gate holds for bob');
+  assert.deepEqual(afterAlice.body.state.awaitingOrders, ['BOB']);
 
-  bob.send({ type: 'order', qty: -4, orderType: 'LIMIT' });
-  bob.send({ type: 'confirmOrder' });
-  await waitFor(() => alice.state?.phase === 'cards', 'orders gate to trip');
+  // Alice's size must not be visible to bob before the gate trips.
+  const bobSees = await get(code, bob.playerToken);
+  assert.equal(bobSees.body.state.reveal, null);
+  assert.ok(!JSON.stringify(bobSees.body.state).includes('"qty":4'));
 
-  // Bob's resting offer covers Alice's demand exactly, so the print is flat.
-  assert.equal(alice.state.reveal.absorbed, 4);
-  assert.equal(alice.state.reveal.imbalance, 0);
-  assert.equal(alice.state.reveal.price, 100);
-  assert.equal(alice.state.reveal.houseResidual, 0);
-  await waitFor(() => alice.me?.fills.length === 1, 'blotter written by the engine');
-  assert.equal(alice.me.fills[0].price, 100);
-  assert.equal(alice.me.fills[0].qty, 4);
+  await act(code, bob.playerToken, 'order', { qty: -4, orderType: 'LIMIT' });
+  const tripped = await act(code, bob.playerToken, 'confirmOrder');
 
-  // Cards
-  alice.send({ type: 'confirmCards' });
-  bob.send({ type: 'confirmCards' });
-  await waitFor(() => alice.state?.phase === 'rolling', 'cards gate to trip');
-  assert.ok(dash.state.net, 'dashboard sees the reveal');
+  assert.equal(tripped.body.state.phase, 'cards');
+  // Bob's resting offer covers alice exactly, so the print is flat.
+  assert.equal(tripped.body.state.reveal.absorbed, 4);
+  assert.equal(tripped.body.state.reveal.imbalance, 0);
+  assert.equal(tripped.body.state.reveal.price, 100);
 
-  for (let i = 0; i < 4; i++) {
-    const before = host.state.rollStep;
-    host.send({ type: 'roll' });
-    await waitFor(() => host.state.rollStep !== before || host.state.round === 2, `die ${i + 1}`);
+  const filled = await get(code, alice.playerToken);
+  assert.equal(filled.body.me.fills.length, 1, 'blotter written by the engine');
+  assert.equal(filled.body.me.fills[0].price, 100);
+  assert.equal(filled.body.me.fills[0].qty, 4);
+
+  await act(code, alice.playerToken, 'confirmCards');
+  const rolling = await act(code, bob.playerToken, 'confirmCards');
+  assert.equal(rolling.body.state.phase, 'rolling');
+
+  for (let i = 0; i < 4; i++) await act(code, hostToken, 'roll');
+
+  const settled = await get(code, alice.playerToken);
+  assert.equal(settled.body.state.round, 2);
+  assert.equal(settled.body.state.history.length, 1);
+  assert.equal(settled.body.state.mark, settled.body.state.history[0].mark);
+
+  // Round 2 to the buzzer.
+  for (const p of [alice, bob]) {
+    await act(code, p.playerToken, 'order', { qty: 0, orderType: 'LIMIT' });
+    await act(code, p.playerToken, 'confirmOrder');
   }
+  for (const p of [alice, bob]) await act(code, p.playerToken, 'confirmCards');
+  for (let i = 0; i < 4; i++) await act(code, hostToken, 'roll');
 
-  await waitFor(() => alice.state?.round === 2, 'round to advance');
-  assert.equal(alice.state.history.length, 1);
-  assert.equal(alice.state.mark, alice.state.history[0].mark);
-
-  // Round 2 — both pass, then roll it out.
-  for (const c of [alice, bob]) {
-    c.send({ type: 'order', qty: 0, orderType: 'LIMIT' });
-    c.send({ type: 'confirmOrder' });
-  }
-  await waitFor(() => alice.state?.phase === 'cards', 'second orders gate');
-  alice.send({ type: 'confirmCards' });
-  bob.send({ type: 'confirmCards' });
-  await waitFor(() => alice.state?.phase === 'rolling', 'second cards gate');
-
-  for (let i = 0; i < 4; i++) {
-    const before = host.state.rollStep;
-    host.send({ type: 'roll' });
-    await waitFor(() => host.state.rollStep !== before || host.state.phase === 'complete', `r2 die ${i + 1}`);
-  }
-
-  await waitFor(() => alice.state?.phase === 'complete', 'game to close');
-
-  // P/L is zero-sum between the two of them: same fill, opposite sides.
-  const s = alice.state.standings;
-  assert.equal(s.reduce((a, p) => a + p.pl, 0), 0);
-
-  [host, dash, alice, bob].forEach((c) => c.close());
+  const done = await get(code, alice.playerToken);
+  assert.equal(done.body.state.phase, 'complete');
+  // Same fill, opposite sides, nothing left with the house.
+  assert.equal(done.body.state.standings.reduce((a, p) => a + p.pl, 0), 0);
 });
 
-test('a player reconnects to the same seat and blotter', async () => {
-  const { code, hostToken } = await (await fetch(`${BASE}/api/games`, {
-    method: 'POST', headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ maxRounds: 1, cardQty: 4 }),
-  })).json();
+// --- Identity and access --------------------------------------------------
 
-  const host = client({ role: 'host', code, hostToken });
-  let carol = client({ role: 'player', code, name: 'carol' });
-  const dave = client({ role: 'player', code, name: 'dave' });
+test('a player rejoins the same seat with their token', async () => {
+  const { code, hostToken } = await newTable({ maxRounds: 1, cardQty: 4 });
+  const carol = await sit(code, 'carol');
+  const dave = await sit(code, 'dave');
 
-  await waitFor(() => host.state?.seated === 2 && carol.seated, 'seated');
-  const token = carol.seated.playerToken;
+  await act(code, hostToken, 'start');
+  await act(code, carol.playerToken, 'order', { qty: 9, orderType: 'MARKET' });
+  await act(code, carol.playerToken, 'confirmOrder');
+  await act(code, dave.playerToken, 'order', { qty: 0, orderType: 'LIMIT' });
+  await act(code, dave.playerToken, 'confirmOrder');
 
-  host.send({ type: 'start' });
-  await waitFor(() => carol.state?.phase === 'orders', 'open');
+  const before = await get(code, carol.playerToken);
+  assert.equal(before.body.me.fills.length, 1);
 
-  carol.send({ type: 'order', qty: 9, orderType: 'MARKET' });
-  carol.send({ type: 'confirmOrder' });
-  dave.send({ type: 'order', qty: 0, orderType: 'LIMIT' });
-  dave.send({ type: 'confirmOrder' });
-  await waitFor(() => carol.me?.fills.length === 1, 'filled');
-  const fills = JSON.stringify(carol.me.fills);
-
-  // Phone sleeps.
-  carol.close();
-  await waitFor(() => host.state.standings.find((p) => p.name === 'CAROL')?.connected === false,
-    'server to notice the drop');
-
-  carol = client({ role: 'player', code, playerToken: token });
-  await waitFor(() => carol.me, 'reconnect');
-
-  assert.equal(carol.me.name, 'CAROL');
-  assert.equal(carol.me.seat, 1);
-  assert.equal(JSON.stringify(carol.me.fills), fills, 'blotter survived the drop');
-
-  [host, carol, dave].forEach((c) => c.close());
+  // Same token after a reload is the same seat, not a new one.
+  const again = await post({ action: 'join', code, token: carol.playerToken, name: 'carol' });
+  assert.equal(again.body.me.seat, 1);
+  assert.equal(again.body.state.seated, 2, 'no duplicate seat created');
+  assert.deepEqual(again.body.me.fills, before.body.me.fills);
 });
 
 test('host controls are refused without the token', async () => {
-  const { code } = await (await fetch(`${BASE}/api/games`, {
-    method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}',
-  })).json();
+  const { code } = await newTable();
+  const player = await sit(code, 'eve');
 
-  const imposter = client({ role: 'host', code, hostToken: 'not-the-token' });
-  await waitFor(() => imposter.errors.length, 'rejection');
-  assert.match(imposter.errors[0], /Bad host token/);
+  const asNobody = await act(code, null, 'start');
+  assert.equal(asNobody.status, 400);
+  assert.match(asNobody.body.error, /Host controls only/);
 
-  // A dashboard cannot drive the game either.
-  const dash = client({ role: 'dashboard', code });
-  await waitFor(() => dash.state, 'dashboard connected');
-  dash.send({ type: 'start' });
-  await waitFor(() => dash.errors.length, 'refusal');
-  assert.match(dash.errors[0], /Host controls only/);
+  const asPlayer = await act(code, player.playerToken, 'start');
+  assert.equal(asPlayer.status, 400);
+  assert.match(asPlayer.body.error, /Host controls only/);
 
-  [imposter, dash].forEach((c) => c.close());
+  const asWrongToken = await act(code, 'not-the-token', 'start');
+  assert.equal(asWrongToken.status, 400);
 });
 
-test('joining an unknown table fails cleanly', async () => {
-  const c = client({ role: 'player', code: 'ZZZZ', name: 'nobody' });
-  await waitFor(() => c.errors.length, 'error');
-  assert.match(c.errors[0], /No table with code/);
-  c.close();
+test('player actions are refused without a seat', async () => {
+  const { code, hostToken } = await newTable();
+  await sit(code, 'frank');
+  await act(code, hostToken, 'start');
+
+  const res = await act(code, hostToken, 'order', { qty: 5, orderType: 'MARKET' });
+  assert.equal(res.status, 400);
+  assert.match(res.body.error, /Not seated/);
 });
 
-test('games survive a server restart', async () => {
-  const { code, hostToken } = await (await fetch(`${BASE}/api/games`, {
-    method: 'POST', headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ maxRounds: 3, cardQty: 5 }),
-  })).json();
+test('an unknown table is a clean 404', async () => {
+  assert.equal((await get('ZZZZ')).status, 404);
+  const joined = await post({ action: 'join', code: 'ZZZZ', name: 'nobody' });
+  assert.equal(joined.status, 400);
+  assert.match(joined.body.error, /No table with code/);
+});
 
-  let host = client({ role: 'host', code, hostToken });
-  const erin = client({ role: 'player', code, name: 'erin' });
-  await waitFor(() => host.state?.seated === 1, 'seated');
-  host.send({ type: 'start' });
-  await waitFor(() => erin.state?.phase === 'orders', 'open');
-  const token = erin.seated.playerToken;
-  host.close(); erin.close();
+test('game-rule violations come back as errors, not crashes', async () => {
+  const { code, hostToken } = await newTable();
+  const p = await sit(code, 'gina');
 
-  // Let the debounced snapshot land, then bounce the process.
-  await new Promise((r) => setTimeout(r, 400));
-  proc.kill('SIGKILL');
-  await new Promise((r) => setTimeout(r, 150));
+  const early = await act(code, p.playerToken, 'order', { qty: 5, orderType: 'MARKET' });
+  assert.equal(early.status, 400);
+  assert.match(early.body.error, /Not accepting orders/);
 
-  proc = spawn(process.execPath, [join(HERE, 'index.js')], {
-    env: { ...process.env, PORT: String(PORT), MOONCOIN_DATA: DATA },
-    stdio: ['ignore', 'pipe', 'pipe'],
-  });
-  await waitFor(async () => {
-    try { return (await fetch(`${BASE}/api/games/${code}`)).status === 200; }
-    catch { return false; }
-  }, 'server to come back with the game');
+  await act(code, hostToken, 'start');
+  const bogus = await act(code, p.playerToken, 'order', { qty: 5, orderType: 'STOP' });
+  assert.equal(bogus.status, 400);
+  assert.match(bogus.body.error, /LIMIT or MARKET/);
 
-  const back = client({ role: 'player', code, playerToken: token });
-  await waitFor(() => back.me, 'rejoin after restart');
-  assert.equal(back.me.name, 'ERIN');
-  assert.equal(back.state.phase, 'orders', 'mid-round state preserved');
-  back.close();
+  const unknown = await act(code, p.playerToken, 'levitate');
+  assert.equal(unknown.status, 400);
+  assert.match(unknown.body.error, /Unknown action/);
+});
+
+test('simultaneous confirms both land', async () => {
+  const { code, hostToken } = await newTable({ maxRounds: 1, cardQty: 4 });
+  const a = await sit(code, 'ann');
+  const b = await sit(code, 'ben');
+  await act(code, hostToken, 'start');
+
+  await act(code, a.playerToken, 'order', { qty: 2, orderType: 'MARKET' });
+  await act(code, b.playerToken, 'order', { qty: -2, orderType: 'LIMIT' });
+
+  // Both confirm at the same instant. Under a lost update one would be dropped
+  // and the gate would never trip.
+  await Promise.all([
+    act(code, a.playerToken, 'confirmOrder'),
+    act(code, b.playerToken, 'confirmOrder'),
+  ]);
+
+  const after = await get(code, a.playerToken);
+  assert.equal(after.body.state.phase, 'cards', 'gate tripped, so both confirms survived');
 });

--- a/mooncoin/server/engine.js
+++ b/mooncoin/server/engine.js
@@ -77,10 +77,21 @@ export function deal(numPlayers, cardQty, rng = Math.random, perType = DEFAULTS.
 /**
  * Aggregate the round's orders into the book display.  Terminal!B20:E20.
  *
- * Orders carry no limit price — only a signed quantity and a type. LIMIT means
- * "passive: rest, don't move the print". MARKET means "aggressive: guaranteed
- * fill, pay the impact". Only market flow enters the imbalance (Terminal!E7),
- * so resting liquidity never moves the price on its own.
+ * Orders carry no limit price — only a signed quantity and a type. A limit
+ * order is resting liquidity at the last sale: marketable, but unwilling to
+ * chase. A market order demands immediacy at whatever the round clears at.
+ *
+ * Market orders net against each other first, and whatever pressure survives
+ * is met by the resting orders facing it. Only what the resting book cannot
+ * absorb becomes imbalance, and only imbalance moves the price:
+ *
+ *   pressure  = market buys - market sells
+ *   resting   = limit orders facing that pressure (offers if buying, bids if selling)
+ *   absorbed  = min(|pressure|, resting)
+ *   imbalance = sign(pressure) * (|pressure| - absorbed)
+ *
+ * Resting orders on the same side as the pressure are not marketable — nobody
+ * is selling at last sale into a bid — so they neither absorb nor trade.
  */
 export function aggregateOrders(orders) {
   let limitBid = 0, limitOffer = 0, marketBid = 0, marketOffer = 0;
@@ -93,7 +104,13 @@ export function aggregateOrders(orders) {
       if (qty > 0) marketBid += qty; else marketOffer += -qty;
     }
   }
-  return { limitBid, limitOffer, marketBid, marketOffer, imbalance: marketBid - marketOffer };
+
+  const pressure = marketBid - marketOffer;
+  const resting = pressure > 0 ? limitOffer : pressure < 0 ? limitBid : 0;
+  const absorbed = Math.min(Math.abs(pressure), resting);
+  const imbalance = Math.sign(pressure) * (Math.abs(pressure) - absorbed);
+
+  return { limitBid, limitOffer, marketBid, marketOffer, pressure, absorbed, imbalance };
 }
 
 /**
@@ -129,49 +146,43 @@ function proRata(wants, available) {
 }
 
 /**
- * Match the round and produce a fill per player, all at the single print price.
+ * Match the round and produce a fill per player, all at the single clearing price.
  *
  * Market orders always fill in full — that certainty is what the square-root
- * slippage buys. Limit orders only trade against opposing market flow, pro-rata
- * when the market side is too small to satisfy everyone, and the house absorbs
- * whatever market volume the resting side could not cover.
+ * slippage buys. Resting orders facing the pressure fill only up to what the
+ * round needed from them, pro-rata when more is offered than required. Resting
+ * orders on the same side as the pressure are not marketable and do not trade.
+ * The house is left holding whatever the players did not net out among
+ * themselves, which is the imbalance by construction.
  */
 export function matchOrders(orders, lastMark) {
   const book = aggregateOrders(orders);
   const price = printPrice(lastMark, book.imbalance);
 
-  const limitBuys = orders.filter((o) => o.type === 'LIMIT' && o.qty > 0);
-  const limitSells = orders.filter((o) => o.type === 'LIMIT' && o.qty < 0);
+  // Only the resting side facing the pressure is marketable this round.
+  const facing = book.pressure > 0
+    ? orders.filter((o) => o.type === 'LIMIT' && o.qty < 0)
+    : book.pressure < 0
+      ? orders.filter((o) => o.type === 'LIMIT' && o.qty > 0)
+      : [];
 
-  // Limit sellers are hit by market buyers; limit buyers are lifted by market sellers.
-  const sellAlloc = proRata(limitSells.map((o) => -o.qty), book.marketBid);
-  const buyAlloc = proRata(limitBuys.map((o) => o.qty), book.marketOffer);
+  const alloc = new Map();
+  const shares = proRata(facing.map((o) => Math.abs(o.qty)), book.absorbed);
+  facing.forEach((o, i) => alloc.set(o, shares[i] * Math.sign(o.qty)));
 
   const fills = [];
   for (const o of orders) {
     const qty = Number(o.qty) || 0;
     if (qty === 0) continue;
-    let filled;
-    if (o.type === 'MARKET') {
-      filled = qty;
-    } else if (qty > 0) {
-      filled = buyAlloc[limitBuys.indexOf(o)];
-    } else {
-      filled = -sellAlloc[limitSells.indexOf(o)];
-    }
+    const filled = o.type === 'MARKET' ? qty : (alloc.get(o) ?? 0);
     if (filled !== 0) fills.push({ playerId: o.playerId, qty: filled, price });
   }
-
-  // Whatever the players do not net out among themselves, the house is on the
-  // other side of. Counting unmatched market volume directly would double-count
-  // opposing market orders, which satisfy each other before the house is needed.
-  const net = fills.reduce((a, f) => a + f.qty, 0);
 
   return {
     ...book,
     price,
     fills,
-    houseResidual: Math.abs(net),
+    houseResidual: Math.abs(fills.reduce((a, f) => a + f.qty, 0)),
   };
 }
 

--- a/mooncoin/server/engine.js
+++ b/mooncoin/server/engine.js
@@ -162,15 +162,16 @@ export function matchOrders(orders, lastMark) {
     if (filled !== 0) fills.push({ playerId: o.playerId, qty: filled, price });
   }
 
-  const limitFilled = sellAlloc.reduce((a, b) => a + b, 0) + buyAlloc.reduce((a, b) => a + b, 0);
-  const marketFilled = book.marketBid + book.marketOffer;
+  // Whatever the players do not net out among themselves, the house is on the
+  // other side of. Counting unmatched market volume directly would double-count
+  // opposing market orders, which satisfy each other before the house is needed.
+  const net = fills.reduce((a, f) => a + f.qty, 0);
 
   return {
     ...book,
     price,
     fills,
-    // Volume the resting book could not supply, absorbed by the house.
-    houseResidual: marketFilled - limitFilled,
+    houseResidual: Math.abs(net),
   };
 }
 

--- a/mooncoin/server/engine.js
+++ b/mooncoin/server/engine.js
@@ -1,0 +1,252 @@
+/**
+ * Mooncoin pricing engine.
+ *
+ * Ported from the "mooncoin base game_master" spreadsheet. Cell references in
+ * comments point at the original Terminal / Player sheets so the provenance of
+ * each rule stays traceable.
+ *
+ * Two prices exist per round, and they are not the same number:
+ *   - the PRINT: what players trade at, derived from order-flow imbalance
+ *   - the MARK:  where the coin settles after the dice, used for mark-to-market
+ */
+
+export const CARD_TYPES = ['up', 'down', 'multiply', 'add'];
+
+export const DEFAULTS = {
+  maxRounds: 5,
+  cardQty: 10,
+  openingPrice: 100,
+  deckPerType: 25,
+};
+
+// ---------------------------------------------------------------------------
+// Deck
+// ---------------------------------------------------------------------------
+
+export function buildDeck(perType = DEFAULTS.deckPerType) {
+  const deck = [];
+  for (const type of CARD_TYPES) {
+    for (let i = 0; i < perType; i++) deck.push(type);
+  }
+  return deck;
+}
+
+/** Fisher-Yates, matching the Apps Script shuffleArray. */
+export function shuffle(deck, rng = Math.random) {
+  const out = deck.slice();
+  for (let i = out.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [out[i], out[j]] = [out[j], out[i]];
+  }
+  return out;
+}
+
+export function emptyHand() {
+  return { up: 0, down: 0, multiply: 0, add: 0 };
+}
+
+/**
+ * Deal `cardQty` cards to each of `numPlayers` seated players.
+ *
+ * The Apps Script always dealt ten hands regardless of how many people were
+ * playing, and silently short-handed later players once the hundred-card deck
+ * ran dry. Here the deal is limited to seated players and an over-subscribed
+ * deck is a hard error rather than a quiet shortfall.
+ */
+export function deal(numPlayers, cardQty, rng = Math.random, perType = DEFAULTS.deckPerType) {
+  const deck = shuffle(buildDeck(perType), rng);
+  if (numPlayers * cardQty > deck.length) {
+    throw new Error(
+      `Deck too small: ${numPlayers} players x ${cardQty} cards exceeds ${deck.length}`
+    );
+  }
+  const hands = [];
+  let i = 0;
+  for (let p = 0; p < numPlayers; p++) {
+    const hand = emptyHand();
+    for (let c = 0; c < cardQty; c++) hand[deck[i++]]++;
+    hands.push(hand);
+  }
+  return hands;
+}
+
+// ---------------------------------------------------------------------------
+// Order book
+// ---------------------------------------------------------------------------
+
+/**
+ * Aggregate the round's orders into the book display.  Terminal!B20:E20.
+ *
+ * Orders carry no limit price — only a signed quantity and a type. LIMIT means
+ * "passive: rest, don't move the print". MARKET means "aggressive: guaranteed
+ * fill, pay the impact". Only market flow enters the imbalance (Terminal!E7),
+ * so resting liquidity never moves the price on its own.
+ */
+export function aggregateOrders(orders) {
+  let limitBid = 0, limitOffer = 0, marketBid = 0, marketOffer = 0;
+  for (const o of orders) {
+    const qty = Number(o.qty) || 0;
+    if (qty === 0) continue;
+    if (o.type === 'LIMIT') {
+      if (qty > 0) limitBid += qty; else limitOffer += -qty;
+    } else if (o.type === 'MARKET') {
+      if (qty > 0) marketBid += qty; else marketOffer += -qty;
+    }
+  }
+  return { limitBid, limitOffer, marketBid, marketOffer, imbalance: marketBid - marketOffer };
+}
+
+/**
+ * Square-root market impact.  Terminal!H7:
+ *   trunc(sqrt(ABS(imb)) + 0.99, 0) * sign(imb) + lastMark
+ * The +0.99/trunc pair is a spreadsheet ceiling; ceil(sqrt(|imb|)) is the same
+ * number for any imbalance a table can generate.
+ */
+export function printPrice(lastMark, imbalance) {
+  if (imbalance === 0) return lastMark;
+  return lastMark + Math.sign(imbalance) * Math.ceil(Math.sqrt(Math.abs(imbalance)));
+}
+
+/**
+ * Largest-remainder apportionment. Guarantees the allocations sum to exactly
+ * `available` so no share is conjured or lost to rounding.
+ */
+function proRata(wants, available) {
+  const total = wants.reduce((a, b) => a + b, 0);
+  if (total === 0) return wants.map(() => 0);
+  if (available >= total) return wants.slice();
+
+  const exact = wants.map((w) => (w * available) / total);
+  const alloc = exact.map(Math.floor);
+  let left = available - alloc.reduce((a, b) => a + b, 0);
+
+  const order = exact
+    .map((e, i) => ({ i, frac: e - Math.floor(e), want: wants[i] }))
+    .sort((a, b) => b.frac - a.frac || b.want - a.want || a.i - b.i);
+
+  for (let k = 0; left > 0; k++, left--) alloc[order[k % order.length].i]++;
+  return alloc;
+}
+
+/**
+ * Match the round and produce a fill per player, all at the single print price.
+ *
+ * Market orders always fill in full — that certainty is what the square-root
+ * slippage buys. Limit orders only trade against opposing market flow, pro-rata
+ * when the market side is too small to satisfy everyone, and the house absorbs
+ * whatever market volume the resting side could not cover.
+ */
+export function matchOrders(orders, lastMark) {
+  const book = aggregateOrders(orders);
+  const price = printPrice(lastMark, book.imbalance);
+
+  const limitBuys = orders.filter((o) => o.type === 'LIMIT' && o.qty > 0);
+  const limitSells = orders.filter((o) => o.type === 'LIMIT' && o.qty < 0);
+
+  // Limit sellers are hit by market buyers; limit buyers are lifted by market sellers.
+  const sellAlloc = proRata(limitSells.map((o) => -o.qty), book.marketBid);
+  const buyAlloc = proRata(limitBuys.map((o) => o.qty), book.marketOffer);
+
+  const fills = [];
+  for (const o of orders) {
+    const qty = Number(o.qty) || 0;
+    if (qty === 0) continue;
+    let filled;
+    if (o.type === 'MARKET') {
+      filled = qty;
+    } else if (qty > 0) {
+      filled = buyAlloc[limitBuys.indexOf(o)];
+    } else {
+      filled = -sellAlloc[limitSells.indexOf(o)];
+    }
+    if (filled !== 0) fills.push({ playerId: o.playerId, qty: filled, price });
+  }
+
+  const limitFilled = sellAlloc.reduce((a, b) => a + b, 0) + buyAlloc.reduce((a, b) => a + b, 0);
+  const marketFilled = book.marketBid + book.marketOffer;
+
+  return {
+    ...book,
+    price,
+    fills,
+    // Volume the resting book could not supply, absorbed by the house.
+    houseResidual: marketFilled - limitFilled,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Cards, regime, dice
+// ---------------------------------------------------------------------------
+
+/** Net direction and magnitude pressure from cards played.  Terminal!G20/H20. */
+export function cardEffects(plays) {
+  let trend = 0, mag = 0;
+  for (const p of plays) {
+    trend += (Number(p.up) || 0) - (Number(p.down) || 0);
+    mag += (Number(p.multiply) || 0) - (Number(p.add) || 0);
+  }
+  return { trend, mag };
+}
+
+/**
+ * Trend persistence.  Terminal!O9/P9.
+ *
+ * When the previous two rounds agreed on direction, the regime leans further
+ * that way; likewise when they agreed on magnitude type. Needs two rounds of
+ * history, so it is inert until round 3.
+ */
+export function regimeEffects(history) {
+  const n = history.length;
+  if (n < 2) return { trend: 0, mag: 0 };
+  const a = history[n - 1];
+  const b = history[n - 2];
+  return {
+    trend: a.trend === b.trend ? a.trend : 0,
+    mag: a.type === b.type ? (a.type === 'MULTIPLY' ? 1 : -1) : 0,
+  };
+}
+
+/**
+ * Resolve four dice into a price change.  Terminal!Z7/AA7/AB7.
+ *
+ * dice = [trendDie, typeDie, A, B], each 1-6.
+ *
+ * The spreadsheet hardcoded the magnitude modifier to zero (Terminal!T7:T16),
+ * which silently made every multiply/add card and the whole type-regime inert.
+ * Wired here as the mirror of the trend side, per the intended design.
+ */
+export function resolveDice(dice, net) {
+  const [trendDie, typeDie, a, b] = dice;
+  const trend = trendDie + net.trend > 3 ? 1 : -1;
+  const type = typeDie + net.mag > 3 ? 'MULTIPLY' : 'ADD';
+  const chg = type === 'MULTIPLY' ? a * b * trend : (a + b) * trend;
+  return { trend, type, chg };
+}
+
+// ---------------------------------------------------------------------------
+// Position accounting
+// ---------------------------------------------------------------------------
+
+/**
+ * Mark-to-market position.  Player!B10/C10/D10.
+ *
+ * P/L on each fill is (mark - fillPrice) * qty, which signs correctly for longs
+ * and shorts alike. Average price is back-solved from the mark and the P/L,
+ * exactly as the sheet did.
+ */
+export function position(fills, mark) {
+  let shares = 0, pl = 0;
+  for (const f of fills) {
+    shares += f.qty;
+    pl += (mark - f.price) * f.qty;
+  }
+  return {
+    shares,
+    pl,
+    avgPrice: shares === 0 ? null : mark - pl / shares,
+  };
+}
+
+export function rollDie(rng = Math.random) {
+  return Math.floor(rng() * 6) + 1;
+}

--- a/mooncoin/server/engine.test.js
+++ b/mooncoin/server/engine.test.js
@@ -1,0 +1,224 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  aggregateOrders, printPrice, matchOrders, cardEffects, regimeEffects,
+  resolveDice, position, deal, buildDeck, shuffle,
+} from './engine.js';
+
+// --- Position math, checked against the live spreadsheet -------------------
+// Player1 held 40 @ 99 and -30 @ 109 against a mark of 115 and showed
+// 10 shares / avg 69.00 / P/L $460.
+
+test('position reproduces the spreadsheet', () => {
+  const p = position([{ qty: 40, price: 99 }, { qty: -30, price: 109 }], 115);
+  assert.equal(p.shares, 10);
+  assert.equal(p.pl, 460);
+  assert.equal(p.avgPrice, 69);
+});
+
+test('position marks a short correctly', () => {
+  const p = position([{ qty: -10, price: 100 }], 90);
+  assert.equal(p.shares, -10);
+  assert.equal(p.pl, 100);
+});
+
+test('flat position has no average price', () => {
+  const p = position([{ qty: 5, price: 100 }, { qty: -5, price: 110 }], 120);
+  assert.equal(p.shares, 0);
+  assert.equal(p.avgPrice, null);
+});
+
+// --- Slippage --------------------------------------------------------------
+
+test('zero imbalance prints flat', () => {
+  assert.equal(printPrice(100, 0), 100);
+});
+
+test('square-root impact, signed', () => {
+  assert.equal(printPrice(100, 1), 101);   // ceil(sqrt(1)) = 1
+  assert.equal(printPrice(100, 4), 102);   // ceil(sqrt(4)) = 2
+  assert.equal(printPrice(100, 5), 103);   // ceil(sqrt(5)) = 3
+  assert.equal(printPrice(100, 9), 103);
+  assert.equal(printPrice(100, 100), 110);
+  assert.equal(printPrice(100, -100), 90);
+});
+
+test('impact matches the sheet ceiling trick', () => {
+  for (let imb = 1; imb <= 500; imb++) {
+    const sheet = Math.trunc(Math.sqrt(imb) + 0.99);
+    assert.equal(printPrice(100, imb) - 100, sheet, `imbalance ${imb}`);
+  }
+});
+
+test('size is self-limiting', () => {
+  // A 100-lot market order moves the print 10 points against itself.
+  assert.equal(printPrice(100, 100) - 100, 10);
+});
+
+// --- Book aggregation ------------------------------------------------------
+
+test('limit orders stay out of the imbalance', () => {
+  const book = aggregateOrders([
+    { playerId: 'a', qty: 10, type: 'LIMIT' },
+    { playerId: 'b', qty: -10, type: 'LIMIT' },
+  ]);
+  assert.equal(book.limitBid, 10);
+  assert.equal(book.limitOffer, 10);
+  assert.equal(book.imbalance, 0);
+});
+
+test('imbalance is market flow only', () => {
+  const book = aggregateOrders([
+    { playerId: 'a', qty: 7, type: 'MARKET' },
+    { playerId: 'b', qty: -2, type: 'MARKET' },
+    { playerId: 'c', qty: 50, type: 'LIMIT' },
+  ]);
+  assert.equal(book.marketBid, 7);
+  assert.equal(book.marketOffer, 2);
+  assert.equal(book.imbalance, 5);
+});
+
+// --- Matching --------------------------------------------------------------
+
+test('market orders always fill; house absorbs the residual', () => {
+  const r = matchOrders([
+    { playerId: 'buyer', qty: 5, type: 'MARKET' },
+    { playerId: 'seller', qty: -3, type: 'LIMIT' },
+  ], 100);
+
+  assert.equal(r.price, 103);                       // ceil(sqrt(5)) = 3
+  const buyer = r.fills.find((f) => f.playerId === 'buyer');
+  const seller = r.fills.find((f) => f.playerId === 'seller');
+  assert.equal(buyer.qty, 5);                       // full fill, certainty bought with slippage
+  assert.equal(seller.qty, -3);                     // resting size was all it had
+  assert.equal(r.houseResidual, 2);
+  for (const f of r.fills) assert.equal(f.price, 103);
+});
+
+test('limit orders fill pro-rata against opposing market flow', () => {
+  const r = matchOrders([
+    { playerId: 'mkt', qty: 6, type: 'MARKET' },
+    { playerId: 'l1', qty: -6, type: 'LIMIT' },
+    { playerId: 'l2', qty: -6, type: 'LIMIT' },
+  ], 100);
+
+  const l1 = r.fills.find((f) => f.playerId === 'l1');
+  const l2 = r.fills.find((f) => f.playerId === 'l2');
+  assert.equal(l1.qty, -3);
+  assert.equal(l2.qty, -3);
+  assert.equal(r.houseResidual, 0);
+});
+
+test('pro-rata allocation never conjures or loses shares', () => {
+  const r = matchOrders([
+    { playerId: 'mkt', qty: 10, type: 'MARKET' },
+    { playerId: 'l1', qty: -3, type: 'LIMIT' },
+    { playerId: 'l2', qty: -5, type: 'LIMIT' },
+    { playerId: 'l3', qty: -7, type: 'LIMIT' },
+  ], 100);
+
+  const limitTotal = r.fills
+    .filter((f) => f.playerId.startsWith('l'))
+    .reduce((a, f) => a + f.qty, 0);
+  assert.equal(limitTotal, -10);   // exactly the market buy volume
+  assert.equal(r.houseResidual, 0);
+});
+
+test('unopposed limit orders do not trade', () => {
+  const r = matchOrders([
+    { playerId: 'a', qty: 10, type: 'LIMIT' },
+    { playerId: 'b', qty: -10, type: 'LIMIT' },
+  ], 100);
+  assert.equal(r.fills.length, 0);
+  assert.equal(r.price, 100);
+});
+
+// --- Cards, regime, dice ---------------------------------------------------
+
+test('card effects net out', () => {
+  const e = cardEffects([
+    { up: 2, down: 0, multiply: 1, add: 0 },
+    { up: 0, down: 3, multiply: 0, add: 2 },
+  ]);
+  assert.deepEqual(e, { trend: -1, mag: -1 });
+});
+
+test('regime is inert before round 3', () => {
+  assert.deepEqual(regimeEffects([]), { trend: 0, mag: 0 });
+  assert.deepEqual(regimeEffects([{ trend: 1, type: 'ADD' }]), { trend: 0, mag: 0 });
+});
+
+test('regime leans with a two-round streak', () => {
+  assert.deepEqual(
+    regimeEffects([{ trend: 1, type: 'MULTIPLY' }, { trend: 1, type: 'MULTIPLY' }]),
+    { trend: 1, mag: 1 }
+  );
+  assert.deepEqual(
+    regimeEffects([{ trend: -1, type: 'ADD' }, { trend: -1, type: 'ADD' }]),
+    { trend: -1, mag: -1 }
+  );
+});
+
+test('regime stays neutral when the streak breaks', () => {
+  assert.deepEqual(
+    regimeEffects([{ trend: 1, type: 'ADD' }, { trend: -1, type: 'MULTIPLY' }]),
+    { trend: 0, mag: 0 }
+  );
+});
+
+test('dice reproduce the spreadsheet round 1', () => {
+  // Terminal V7:Y7 = 4,5,5,3 produced Chg 15, Trend 1, Type MULTIPLY.
+  const r = resolveDice([4, 5, 5, 3], { trend: 0, mag: 0 });
+  assert.equal(r.trend, 1);
+  assert.equal(r.type, 'MULTIPLY');
+  assert.equal(r.chg, 15);
+});
+
+test('trend die threshold sits above 3', () => {
+  assert.equal(resolveDice([3, 5, 2, 2], { trend: 0, mag: 0 }).trend, -1);
+  assert.equal(resolveDice([4, 5, 2, 2], { trend: 0, mag: 0 }).trend, 1);
+});
+
+test('cards can flip the dice', () => {
+  // A 3 on the trend die falls short alone, but one net up-card carries it.
+  assert.equal(resolveDice([3, 5, 2, 2], { trend: 0, mag: 0 }).trend, -1);
+  assert.equal(resolveDice([3, 5, 2, 2], { trend: 1, mag: 0 }).trend, 1);
+});
+
+test('magnitude cards are live, unlike the sheet', () => {
+  // The spreadsheet hardcoded this modifier to zero; here it bites.
+  assert.equal(resolveDice([5, 3, 4, 4], { trend: 0, mag: 0 }).type, 'ADD');
+  assert.equal(resolveDice([5, 3, 4, 4], { trend: 0, mag: 1 }).type, 'MULTIPLY');
+  assert.equal(resolveDice([5, 3, 4, 4], { trend: 0, mag: 0 }).chg, 8);   // 4+4
+  assert.equal(resolveDice([5, 3, 4, 4], { trend: 0, mag: 1 }).chg, 16);  // 4*4
+});
+
+// --- Dealing ---------------------------------------------------------------
+
+test('deck is 100 cards, 25 of each type', () => {
+  const deck = buildDeck();
+  assert.equal(deck.length, 100);
+  for (const t of ['up', 'down', 'multiply', 'add']) {
+    assert.equal(deck.filter((c) => c === t).length, 25);
+  }
+});
+
+test('every player gets a full hand', () => {
+  const hands = deal(4, 10);
+  assert.equal(hands.length, 4);
+  for (const h of hands) {
+    assert.equal(h.up + h.down + h.multiply + h.add, 10);
+  }
+});
+
+test('an oversubscribed deck is an error, not a short hand', () => {
+  assert.throws(() => deal(10, 11), /Deck too small/);
+  assert.doesNotThrow(() => deal(10, 10));
+});
+
+test('shuffle preserves deck composition', () => {
+  const deck = buildDeck();
+  const shuffled = shuffle(deck);
+  assert.equal(shuffled.length, 100);
+  assert.deepEqual(shuffled.slice().sort(), deck.slice().sort());
+});

--- a/mooncoin/server/engine.test.js
+++ b/mooncoin/server/engine.test.js
@@ -57,7 +57,7 @@ test('size is self-limiting', () => {
 
 // --- Book aggregation ------------------------------------------------------
 
-test('limit orders stay out of the imbalance', () => {
+test('resting liquidity alone creates no pressure', () => {
   const book = aggregateOrders([
     { playerId: 'a', qty: 10, type: 'LIMIT' },
     { playerId: 'b', qty: -10, type: 'LIMIT' },
@@ -67,45 +67,130 @@ test('limit orders stay out of the imbalance', () => {
   assert.equal(book.imbalance, 0);
 });
 
-test('imbalance is market flow only', () => {
+test('resting offers absorb buying pressure exactly', () => {
+  // 5 to buy at market, 5 resting to sell — the sellers cover it, nothing moves.
   const book = aggregateOrders([
-    { playerId: 'a', qty: 7, type: 'MARKET' },
-    { playerId: 'b', qty: -2, type: 'MARKET' },
-    { playerId: 'c', qty: 50, type: 'LIMIT' },
+    { playerId: 'a', qty: 5, type: 'MARKET' },
+    { playerId: 'b', qty: -5, type: 'LIMIT' },
   ]);
-  assert.equal(book.marketBid, 7);
-  assert.equal(book.marketOffer, 2);
-  assert.equal(book.imbalance, 5);
+  assert.equal(book.pressure, 5);
+  assert.equal(book.absorbed, 5);
+  assert.equal(book.imbalance, 0);
+});
+
+test('what the resting book cannot cover becomes imbalance', () => {
+  // Same 5 to buy, but only 2 resting to sell — 3 is left wanting.
+  const book = aggregateOrders([
+    { playerId: 'a', qty: 5, type: 'MARKET' },
+    { playerId: 'b', qty: -2, type: 'LIMIT' },
+  ]);
+  assert.equal(book.absorbed, 2);
+  assert.equal(book.imbalance, 3);
+  assert.equal(printPrice(100, book.imbalance), 102);   // ceil(sqrt(3)) = 2
+});
+
+test('resting orders on the pressure side are not marketable', () => {
+  // 10 to buy at market and 10 more resting to buy. Nobody is selling at last
+  // sale into that, so the resting bid absorbs nothing.
+  const book = aggregateOrders([
+    { playerId: 'a', qty: 10, type: 'MARKET' },
+    { playerId: 'b', qty: 10, type: 'LIMIT' },
+  ]);
+  assert.equal(book.limitBid, 10);
+  assert.equal(book.absorbed, 0);
+  assert.equal(book.imbalance, 10);
+});
+
+test('market orders net before the resting book is called on', () => {
+  // 10 to buy market, 3 to sell market, 5 resting to sell.
+  const book = aggregateOrders([
+    { playerId: 'a', qty: 10, type: 'MARKET' },
+    { playerId: 'b', qty: -3, type: 'MARKET' },
+    { playerId: 'c', qty: -5, type: 'LIMIT' },
+  ]);
+  assert.equal(book.pressure, 7);
+  assert.equal(book.absorbed, 5);
+  assert.equal(book.imbalance, 2);
+});
+
+test('surplus resting liquidity cannot flip the price', () => {
+  // 5 to buy against 30 resting to sell: the imbalance floors at zero rather
+  // than turning negative and ticking the price down.
+  const book = aggregateOrders([
+    { playerId: 'a', qty: 5, type: 'MARKET' },
+    { playerId: 'b', qty: -30, type: 'LIMIT' },
+  ]);
+  assert.equal(book.absorbed, 5);
+  assert.equal(book.imbalance, 0);
 });
 
 // --- Matching --------------------------------------------------------------
 
-test('market orders always fill; house absorbs the residual', () => {
+test('a fully covered market order prints flat', () => {
+  const r = matchOrders([
+    { playerId: 'buyer', qty: 5, type: 'MARKET' },
+    { playerId: 'seller', qty: -5, type: 'LIMIT' },
+  ], 100);
+
+  assert.equal(r.price, 100, 'the resting offer covered it, so nothing moved');
+  assert.equal(r.fills.find((f) => f.playerId === 'buyer').qty, 5);
+  assert.equal(r.fills.find((f) => f.playerId === 'seller').qty, -5);
+  assert.equal(r.houseResidual, 0);
+});
+
+test('market orders always fill; house takes what is left', () => {
   const r = matchOrders([
     { playerId: 'buyer', qty: 5, type: 'MARKET' },
     { playerId: 'seller', qty: -3, type: 'LIMIT' },
   ], 100);
 
-  assert.equal(r.price, 103);                       // ceil(sqrt(5)) = 3
-  const buyer = r.fills.find((f) => f.playerId === 'buyer');
-  const seller = r.fills.find((f) => f.playerId === 'seller');
-  assert.equal(buyer.qty, 5);                       // full fill, certainty bought with slippage
-  assert.equal(seller.qty, -3);                     // resting size was all it had
+  assert.equal(r.price, 102);                       // imbalance 3, ceil(sqrt(3)) = 2
+  assert.equal(r.fills.find((f) => f.playerId === 'buyer').qty, 5);
+  assert.equal(r.fills.find((f) => f.playerId === 'seller').qty, -3);
   assert.equal(r.houseResidual, 2);
-  for (const f of r.fills) assert.equal(f.price, 103);
+  for (const f of r.fills) assert.equal(f.price, 102);
 });
 
-test('limit orders fill pro-rata against opposing market flow', () => {
+test('a resting order on the pressure side does not trade', () => {
+  const r = matchOrders([
+    { playerId: 'mkt', qty: 10, type: 'MARKET' },
+    { playerId: 'rest', qty: 10, type: 'LIMIT' },
+  ], 100);
+
+  assert.equal(r.price, 104);                       // ceil(sqrt(10)) = 4
+  assert.equal(r.fills.find((f) => f.playerId === 'mkt').qty, 10);
+  assert.equal(r.fills.find((f) => f.playerId === 'rest'), undefined);
+  assert.equal(r.houseResidual, 10);
+});
+
+test('everyone fills at the clearing price', () => {
+  // 10 to buy market, 5 resting to sell, 3 to sell market -> imbalance +2.
+  const r = matchOrders([
+    { playerId: 'buyer', qty: 10, type: 'MARKET' },
+    { playerId: 'rester', qty: -5, type: 'LIMIT' },
+    { playerId: 'seller', qty: -3, type: 'MARKET' },
+  ], 100);
+
+  assert.equal(r.imbalance, 2);
+  assert.equal(r.price, 102);                       // ceil(sqrt(2)) = 2
+  assert.equal(r.fills.length, 3, 'everyone trades');
+  assert.equal(r.fills.find((f) => f.playerId === 'buyer').qty, 10);
+  assert.equal(r.fills.find((f) => f.playerId === 'rester').qty, -5);
+  assert.equal(r.fills.find((f) => f.playerId === 'seller').qty, -3);
+  for (const f of r.fills) assert.equal(f.price, 102);
+  assert.equal(r.houseResidual, 2);
+});
+
+test('oversubscribed resting orders fill pro-rata', () => {
   const r = matchOrders([
     { playerId: 'mkt', qty: 6, type: 'MARKET' },
     { playerId: 'l1', qty: -6, type: 'LIMIT' },
     { playerId: 'l2', qty: -6, type: 'LIMIT' },
   ], 100);
 
-  const l1 = r.fills.find((f) => f.playerId === 'l1');
-  const l2 = r.fills.find((f) => f.playerId === 'l2');
-  assert.equal(l1.qty, -3);
-  assert.equal(l2.qty, -3);
+  assert.equal(r.price, 100, 'twelve offered covers six wanted');
+  assert.equal(r.fills.find((f) => f.playerId === 'l1').qty, -3);
+  assert.equal(r.fills.find((f) => f.playerId === 'l2').qty, -3);
   assert.equal(r.houseResidual, 0);
 });
 
@@ -120,8 +205,20 @@ test('pro-rata allocation never conjures or loses shares', () => {
   const limitTotal = r.fills
     .filter((f) => f.playerId.startsWith('l'))
     .reduce((a, f) => a + f.qty, 0);
-  assert.equal(limitTotal, -10);   // exactly the market buy volume
+  assert.equal(limitTotal, -10);   // exactly what the round needed
   assert.equal(r.houseResidual, 0);
+});
+
+test('resting bids absorb selling pressure the same way', () => {
+  const r = matchOrders([
+    { playerId: 'seller', qty: -9, type: 'MARKET' },
+    { playerId: 'rester', qty: 4, type: 'LIMIT' },
+  ], 100);
+
+  assert.equal(r.imbalance, -5);
+  assert.equal(r.price, 97);                        // 100 - ceil(sqrt(5))
+  assert.equal(r.fills.find((f) => f.playerId === 'rester').qty, 4);
+  assert.equal(r.houseResidual, 5);
 });
 
 test('opposing market orders satisfy each other before the house', () => {
@@ -135,19 +232,23 @@ test('opposing market orders satisfy each other before the house', () => {
   assert.equal(r.houseResidual, 5, 'the four that crossed need no house');
 });
 
-test('house residual always equals the unmatched net', () => {
+test('house residual is always exactly the imbalance', () => {
   const books = [
     [['a', 4, 'MARKET'], ['b', -4, 'LIMIT']],
     [['a', 5, 'MARKET'], ['b', -3, 'LIMIT']],
     [['a', 9, 'MARKET'], ['b', -4, 'MARKET']],
     [['a', 6, 'MARKET'], ['b', 6, 'MARKET'], ['c', -4, 'LIMIT']],
     [['a', 20, 'LIMIT'], ['b', -20, 'LIMIT']],
+    [['a', 10, 'MARKET'], ['b', -3, 'MARKET'], ['c', -5, 'LIMIT']],
+    [['a', 10, 'MARKET'], ['b', 10, 'LIMIT']],
+    [['a', -9, 'MARKET'], ['b', 4, 'LIMIT'], ['c', -2, 'LIMIT']],
   ];
   for (const spec of books) {
     const orders = spec.map(([playerId, qty, type]) => ({ playerId, qty, type }));
     const r = matchOrders(orders, 100);
     const net = r.fills.reduce((a, f) => a + f.qty, 0);
     assert.equal(r.houseResidual, Math.abs(net), JSON.stringify(spec));
+    assert.equal(r.houseResidual, Math.abs(r.imbalance), JSON.stringify(spec));
   }
 });
 

--- a/mooncoin/server/engine.test.js
+++ b/mooncoin/server/engine.test.js
@@ -124,6 +124,33 @@ test('pro-rata allocation never conjures or loses shares', () => {
   assert.equal(r.houseResidual, 0);
 });
 
+test('opposing market orders satisfy each other before the house', () => {
+  const r = matchOrders([
+    { playerId: 'buyer', qty: 9, type: 'MARKET' },
+    { playerId: 'seller', qty: -4, type: 'MARKET' },
+  ], 100);
+
+  assert.equal(r.imbalance, 5);
+  assert.equal(r.price, 103);
+  assert.equal(r.houseResidual, 5, 'the four that crossed need no house');
+});
+
+test('house residual always equals the unmatched net', () => {
+  const books = [
+    [['a', 4, 'MARKET'], ['b', -4, 'LIMIT']],
+    [['a', 5, 'MARKET'], ['b', -3, 'LIMIT']],
+    [['a', 9, 'MARKET'], ['b', -4, 'MARKET']],
+    [['a', 6, 'MARKET'], ['b', 6, 'MARKET'], ['c', -4, 'LIMIT']],
+    [['a', 20, 'LIMIT'], ['b', -20, 'LIMIT']],
+  ];
+  for (const spec of books) {
+    const orders = spec.map(([playerId, qty, type]) => ({ playerId, qty, type }));
+    const r = matchOrders(orders, 100);
+    const net = r.fills.reduce((a, f) => a + f.qty, 0);
+    assert.equal(r.houseResidual, Math.abs(net), JSON.stringify(spec));
+  }
+});
+
 test('unopposed limit orders do not trade', () => {
   const r = matchOrders([
     { playerId: 'a', qty: 10, type: 'LIMIT' },

--- a/mooncoin/server/game.js
+++ b/mooncoin/server/game.js
@@ -405,7 +405,6 @@ export function standings(game) {
       id: p.id,
       seat: p.seat,
       name: p.name,
-      connected: p.connected,
       ...position(p.fills, game.mark),
       cardsLeft: p.hand.up + p.hand.down + p.hand.multiply + p.hand.add,
       ordersReady: !!game.ready.orders[p.id],

--- a/mooncoin/server/game.js
+++ b/mooncoin/server/game.js
@@ -308,6 +308,8 @@ function settleRound(game) {
     imbalance: game.reveal.imbalance,
     marketOffer: game.reveal.marketOffer,
     limitOffer: game.reveal.limitOffer,
+    pressure: game.reveal.pressure,
+    absorbed: game.reveal.absorbed,
     print: game.reveal.price,
     houseResidual: game.reveal.houseResidual,
     regime: game.net.regime,

--- a/mooncoin/server/game.js
+++ b/mooncoin/server/game.js
@@ -1,0 +1,469 @@
+/**
+ * Game state machine.
+ *
+ * A round runs through two gates, mirroring the two ready-columns the
+ * spreadsheet tracked:
+ *
+ *   orders  -> everyone submits qty + LIMIT/MARKET and confirms
+ *              (gate) reveal the book, print the fill, write every blotter
+ *   cards   -> everyone plays cards and confirms
+ *              (gate) reveal cards, compute the net, hand off to the dice
+ *   rolling -> four dice, locked one at a time for the theatre of it
+ *              (gate) apply the change, set the new mark, advance
+ *
+ * Gates trip automatically once every seated player has confirmed. The host can
+ * force any gate to unstick a table when somebody wanders off.
+ */
+
+import {
+  DEFAULTS, deal, emptyHand, matchOrders, cardEffects, regimeEffects,
+  resolveDice, position, rollDie,
+} from './engine.js';
+
+export const PHASES = ['lobby', 'orders', 'cards', 'rolling', 'complete'];
+
+const CODE_ALPHABET = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'; // no I/O/0/1
+
+export function makeRoomCode(rng = Math.random) {
+  let s = '';
+  for (let i = 0; i < 4; i++) s += CODE_ALPHABET[Math.floor(rng() * CODE_ALPHABET.length)];
+  return s;
+}
+
+export function createGame(code, config = {}) {
+  return {
+    code,
+    createdAt: Date.now(),
+    config: {
+      maxRounds: config.maxRounds ?? DEFAULTS.maxRounds,
+      cardQty: config.cardQty ?? DEFAULTS.cardQty,
+      openingPrice: config.openingPrice ?? DEFAULTS.openingPrice,
+    },
+    phase: 'lobby',
+    round: 0,
+    mark: config.openingPrice ?? DEFAULTS.openingPrice,
+    players: [],
+    dice: [null, null, null, null],
+    pendingOrders: {},   // playerId -> { qty, type }
+    pendingCards: {},    // playerId -> { up, down, multiply, add }
+    ready: { orders: {}, cards: {} },
+    reveal: null,        // this round's matched book, once the orders gate trips
+    net: null,           // this round's trend/magnitude pressure, once cards trip
+    history: [],         // one entry per completed round
+    log: [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Players
+// ---------------------------------------------------------------------------
+
+export function addPlayer(game, name) {
+  if (game.phase !== 'lobby') throw new Error('Game already under way');
+  if (game.players.length >= 10) throw new Error('Table is full (10 seats)');
+
+  const clean = String(name || '').trim().slice(0, 20).toUpperCase();
+  if (!clean) throw new Error('Name required');
+  if (game.players.some((p) => p.name === clean)) throw new Error(`${clean} is already seated`);
+
+  const player = {
+    id: `p${game.players.length + 1}_${Math.random().toString(36).slice(2, 8)}`,
+    seat: game.players.length + 1,
+    name: clean,
+    connected: true,
+    hand: emptyHand(),
+    initialHand: emptyHand(),
+    fills: [],
+  };
+  game.players.push(player);
+  logLine(game, `${clean} took seat ${player.seat}`);
+  return player;
+}
+
+export function removePlayer(game, playerId) {
+  if (game.phase !== 'lobby') return false;
+  const i = game.players.findIndex((p) => p.id === playerId);
+  if (i === -1) return false;
+  const [gone] = game.players.splice(i, 1);
+  game.players.forEach((p, idx) => { p.seat = idx + 1; });
+  logLine(game, `${gone.name} left the table`);
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+export function startGame(game, rng = Math.random) {
+  if (game.phase !== 'lobby') throw new Error('Game already started');
+  if (game.players.length < 1) throw new Error('Need at least one player');
+
+  const hands = deal(game.players.length, game.config.cardQty, rng);
+  game.players.forEach((p, i) => {
+    p.hand = { ...hands[i] };
+    p.initialHand = { ...hands[i] };
+    p.fills = [];
+  });
+
+  game.round = 1;
+  game.mark = game.config.openingPrice;
+  game.phase = 'orders';
+  game.history = [];
+  clearRound(game);
+  logLine(game, `Game opened at ${game.config.openingPrice} — ${game.config.maxRounds} rounds, ${game.config.cardQty} cards each`);
+  return game;
+}
+
+function clearRound(game) {
+  game.pendingOrders = {};
+  game.pendingCards = {};
+  game.ready = { orders: {}, cards: {} };
+  game.reveal = null;
+  game.net = null;
+  game.dice = [null, null, null, null];
+}
+
+function logLine(game, text) {
+  game.log.push({ t: Date.now(), round: game.round, text });
+  if (game.log.length > 200) game.log.shift();
+}
+
+// ---------------------------------------------------------------------------
+// Orders phase
+// ---------------------------------------------------------------------------
+
+export function submitOrder(game, playerId, { qty, type }) {
+  if (game.phase !== 'orders') throw new Error('Not accepting orders');
+  if (game.ready.orders[playerId]) throw new Error('Order already confirmed');
+
+  const n = Math.trunc(Number(qty));
+  if (!Number.isFinite(n)) throw new Error('Quantity must be a number');
+  if (type !== 'LIMIT' && type !== 'MARKET') throw new Error('Order type must be LIMIT or MARKET');
+
+  game.pendingOrders[playerId] = { qty: n, type };
+  return game.pendingOrders[playerId];
+}
+
+export function confirmOrder(game, playerId) {
+  if (game.phase !== 'orders') throw new Error('Not accepting orders');
+  if (!game.pendingOrders[playerId]) throw new Error('Nothing submitted yet');
+  game.ready.orders[playerId] = true;
+  const p = playerById(game, playerId);
+  logLine(game, `${p.name} confirmed order`);
+  return maybeTripOrdersGate(game);
+}
+
+export function unconfirmOrder(game, playerId) {
+  if (game.phase !== 'orders') return false;
+  delete game.ready.orders[playerId];
+  return true;
+}
+
+export function allOrdersReady(game) {
+  return game.players.length > 0 && game.players.every((p) => game.ready.orders[p.id]);
+}
+
+function maybeTripOrdersGate(game, force = false) {
+  if (!force && !allOrdersReady(game)) return false;
+  return tripOrdersGate(game);
+}
+
+/** Reveal the book, print the round, and write every blotter. */
+export function tripOrdersGate(game) {
+  if (game.phase !== 'orders') throw new Error('Orders gate is not open');
+
+  // Only confirmed orders trade. Typing a quantity is not committing to it, so
+  // a forced gate leaves the undecided flat rather than filling them by default.
+  const orders = game.players
+    .filter((p) => game.ready.orders[p.id] && game.pendingOrders[p.id])
+    .map((p) => ({ playerId: p.id, ...game.pendingOrders[p.id] }));
+
+  const result = matchOrders(orders, game.mark);
+
+  for (const fill of result.fills) {
+    playerById(game, fill.playerId).fills.push({
+      round: game.round, qty: fill.qty, price: fill.price,
+    });
+  }
+
+  game.reveal = {
+    ...result,
+    orders: orders.map((o) => ({
+      playerId: o.playerId,
+      name: playerById(game, o.playerId).name,
+      qty: o.qty,
+      type: o.type,
+      filled: result.fills.find((f) => f.playerId === o.playerId)?.qty ?? 0,
+    })),
+  };
+  game.phase = 'cards';
+  logLine(game, `Round ${game.round} printed ${result.price} on imbalance ${result.imbalance >= 0 ? '+' : ''}${result.imbalance}`);
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Cards phase
+// ---------------------------------------------------------------------------
+
+export function submitCards(game, playerId, play) {
+  if (game.phase !== 'cards') throw new Error('Not accepting cards');
+  if (game.ready.cards[playerId]) throw new Error('Cards already confirmed');
+
+  const p = playerById(game, playerId);
+  const clean = emptyHand();
+  for (const k of Object.keys(clean)) {
+    const n = Math.trunc(Number(play?.[k]) || 0);
+    if (n < 0) throw new Error('Cannot play a negative number of cards');
+    if (n > p.hand[k]) throw new Error(`Only ${p.hand[k]} ${k} card(s) in hand`);
+    clean[k] = n;
+  }
+  game.pendingCards[playerId] = clean;
+  return clean;
+}
+
+export function confirmCards(game, playerId) {
+  if (game.phase !== 'cards') throw new Error('Not accepting cards');
+  if (!game.pendingCards[playerId]) game.pendingCards[playerId] = emptyHand();
+  game.ready.cards[playerId] = true;
+  const p = playerById(game, playerId);
+  logLine(game, `${p.name} confirmed cards`);
+  return maybeTripCardsGate(game);
+}
+
+export function unconfirmCards(game, playerId) {
+  if (game.phase !== 'cards') return false;
+  delete game.ready.cards[playerId];
+  return true;
+}
+
+export function allCardsReady(game) {
+  return game.players.length > 0 && game.players.every((p) => game.ready.cards[p.id]);
+}
+
+function maybeTripCardsGate(game, force = false) {
+  if (!force && !allCardsReady(game)) return false;
+  return tripCardsGate(game);
+}
+
+/** Reveal cards, spend them, and compute the pressure the dice will feel. */
+export function tripCardsGate(game) {
+  if (game.phase !== 'cards') throw new Error('Cards gate is not open');
+
+  // Same rule as orders: unconfirmed cards stay in hand and cost nothing.
+  const plays = [];
+  for (const p of game.players) {
+    const play = (game.ready.cards[p.id] && game.pendingCards[p.id]) || emptyHand();
+    for (const k of Object.keys(play)) p.hand[k] -= play[k];
+    plays.push({ ...play, playerId: p.id, name: p.name });
+  }
+
+  const cards = cardEffects(plays);
+  const regime = regimeEffects(game.history);
+
+  game.net = {
+    cards,
+    regime,
+    trend: regime.trend + cards.trend,
+    mag: regime.mag + cards.mag,
+    plays,
+  };
+  game.phase = 'rolling';
+  logLine(game, `Cards revealed — net trend ${fmtSigned(game.net.trend)}, net magnitude ${fmtSigned(game.net.mag)}`);
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Rolling phase
+// ---------------------------------------------------------------------------
+
+export const DIE_LABELS = ['Trend Die', 'Multiply/Add Die', 'D6 (A)', 'D6 (B)'];
+
+export function rollStep(game) {
+  return game.dice.filter((d) => d !== null).length;
+}
+
+/** Roll and lock the next die. The fourth one closes the round. */
+export function lockRoll(game, rng = Math.random, forced = null) {
+  if (game.phase !== 'rolling') throw new Error('Not rolling');
+  const step = rollStep(game);
+  if (step >= 4) throw new Error('All four dice are locked');
+
+  const value = forced ?? rollDie(rng);
+  game.dice[step] = value;
+  logLine(game, `${DIE_LABELS[step]}: ${value}`);
+
+  if (rollStep(game) === 4) return settleRound(game);
+  return { settled: false };
+}
+
+function settleRound(game) {
+  const { trend, type, chg } = resolveDice(game.dice, game.net);
+  const priorMark = game.mark;
+  game.mark = priorMark + chg;
+
+  game.history.push({
+    round: game.round,
+    limitBid: game.reveal.limitBid,
+    marketBid: game.reveal.marketBid,
+    imbalance: game.reveal.imbalance,
+    marketOffer: game.reveal.marketOffer,
+    limitOffer: game.reveal.limitOffer,
+    print: game.reveal.price,
+    houseResidual: game.reveal.houseResidual,
+    regime: game.net.regime,
+    cards: game.net.cards,
+    plays: game.net.plays,
+    net: { trend: game.net.trend, mag: game.net.mag },
+    dice: game.dice.slice(),
+    trend,
+    type,
+    chg,
+    priorMark,
+    mark: game.mark,
+  });
+
+  logLine(game, `Round ${game.round} settled ${fmtSigned(chg)} to ${game.mark} (${type})`);
+
+  if (game.round >= game.config.maxRounds) {
+    game.phase = 'complete';
+    logLine(game, `Game over — final mark ${game.mark}`);
+  } else {
+    game.round += 1;
+    game.phase = 'orders';
+    clearRound(game);
+  }
+  return { settled: true, trend, type, chg, mark: game.mark };
+}
+
+// ---------------------------------------------------------------------------
+// Host overrides
+// ---------------------------------------------------------------------------
+
+export function forceGate(game) {
+  if (game.phase === 'orders') {
+    // Anyone who never submitted sits the round out flat.
+    logLine(game, 'Host forced the orders gate');
+    return maybeTripOrdersGate(game, true);
+  }
+  if (game.phase === 'cards') {
+    logLine(game, 'Host forced the cards gate');
+    return maybeTripCardsGate(game, true);
+  }
+  throw new Error('No gate to force in this phase');
+}
+
+export function resetGame(game) {
+  game.phase = 'lobby';
+  game.round = 0;
+  game.mark = game.config.openingPrice;
+  game.history = [];
+  game.log = [];
+  clearRound(game);
+  for (const p of game.players) {
+    p.hand = emptyHand();
+    p.initialHand = emptyHand();
+    p.fills = [];
+  }
+  logLine(game, 'Game reset to lobby');
+}
+
+export function updateConfig(game, patch) {
+  if (game.phase !== 'lobby') throw new Error('Config is locked once the game starts');
+  const next = { ...game.config, ...patch };
+  next.maxRounds = clampInt(next.maxRounds, 1, 10);
+  next.cardQty = clampInt(next.cardQty, 0, 25);
+  next.openingPrice = clampInt(next.openingPrice, 1, 10000);
+  if (game.players.length * next.cardQty > 100) {
+    throw new Error(`${game.players.length} players x ${next.cardQty} cards exceeds the 100-card deck`);
+  }
+  game.config = next;
+  game.mark = next.openingPrice;
+  return next;
+}
+
+function clampInt(v, lo, hi) {
+  const n = Math.trunc(Number(v));
+  if (!Number.isFinite(n)) throw new Error('Expected a number');
+  return Math.min(hi, Math.max(lo, n));
+}
+
+// ---------------------------------------------------------------------------
+// Views
+// ---------------------------------------------------------------------------
+
+export function playerById(game, id) {
+  const p = game.players.find((x) => x.id === id);
+  if (!p) throw new Error('Unknown player');
+  return p;
+}
+
+export function standings(game) {
+  return game.players
+    .map((p) => ({
+      id: p.id,
+      seat: p.seat,
+      name: p.name,
+      connected: p.connected,
+      ...position(p.fills, game.mark),
+      cardsLeft: p.hand.up + p.hand.down + p.hand.multiply + p.hand.add,
+      ordersReady: !!game.ready.orders[p.id],
+      cardsReady: !!game.ready.cards[p.id],
+      submittedOrder: !!game.pendingOrders[p.id],
+      submittedCards: !!game.pendingCards[p.id],
+    }))
+    .sort((a, b) => b.pl - a.pl || a.seat - b.seat);
+}
+
+/**
+ * What everyone can see. Orders and cards stay hidden until their gate trips —
+ * the reveal is the whole drama, so this is the one thing worth being strict about.
+ */
+export function publicState(game) {
+  return {
+    code: game.code,
+    phase: game.phase,
+    round: game.round,
+    maxRounds: game.config.maxRounds,
+    cardQty: game.config.cardQty,
+    mark: game.mark,
+    openingPrice: game.config.openingPrice,
+    standings: standings(game),
+    history: game.history,
+    reveal: game.phase === 'orders' ? null : game.reveal,
+    net: game.phase === 'orders' || game.phase === 'cards' ? null : game.net,
+    dice: game.dice,
+    rollStep: rollStep(game),
+    dieLabel: DIE_LABELS[rollStep(game)] ?? null,
+    log: game.log.slice(-40),
+    seated: game.players.length,
+    // Counts only — knowing three people have committed is fair game, knowing
+    // what they committed is not.
+    awaitingOrders: game.players.filter((p) => !game.ready.orders[p.id]).map((p) => p.name),
+    awaitingCards: game.players.filter((p) => !game.ready.cards[p.id]).map((p) => p.name),
+  };
+}
+
+/** Everything above, plus this player's own private hand, order and blotter. */
+export function privateState(game, playerId) {
+  const p = game.players.find((x) => x.id === playerId);
+  if (!p) return null;
+  return {
+    me: {
+      id: p.id,
+      seat: p.seat,
+      name: p.name,
+      hand: p.hand,
+      initialHand: p.initialHand,
+      fills: p.fills,
+      ...position(p.fills, game.mark),
+      pendingOrder: game.pendingOrders[p.id] ?? null,
+      pendingCards: game.pendingCards[p.id] ?? null,
+      ordersReady: !!game.ready.orders[p.id],
+      cardsReady: !!game.ready.cards[p.id],
+    },
+  };
+}
+
+function fmtSigned(n) {
+  return n >= 0 ? `+${n}` : `${n}`;
+}

--- a/mooncoin/server/game.test.js
+++ b/mooncoin/server/game.test.js
@@ -206,13 +206,17 @@ test('a full game settles P/L consistently', () => {
   const { g, players } = tableOf(['buyer', 'seller'], { maxRounds: 2 });
   const [buyer, seller] = players;
 
-  // Round 1: buyer lifts 4 at market, seller rests 4.
-  submitOrder(g, buyer.id, { qty: 4, type: 'MARKET' });
+  // Round 1: buyer takes 5 at market, seller only rests 3 — two go uncovered.
+  submitOrder(g, buyer.id, { qty: 5, type: 'MARKET' });
   confirmOrder(g, buyer.id);
-  submitOrder(g, seller.id, { qty: -4, type: 'LIMIT' });
+  submitOrder(g, seller.id, { qty: -3, type: 'LIMIT' });
   confirmOrder(g, seller.id);
 
-  assert.equal(g.reveal.price, 102);     // 100 + ceil(sqrt(4))
+  assert.equal(g.reveal.absorbed, 3);
+  assert.equal(g.reveal.imbalance, 2);
+  assert.equal(g.reveal.price, 102);     // 100 + ceil(sqrt(2))
+  assert.equal(g.reveal.houseResidual, 2);
+
   for (const p of players) confirmCards(g, p.id);
   roll(g, [4, 5, 5, 3]);                 // +15 -> mark 115
 
@@ -220,11 +224,12 @@ test('a full game settles P/L consistently', () => {
   const s = standings(g);
   const b = s.find((x) => x.name === 'BUYER');
   const l = s.find((x) => x.name === 'SELLER');
-  assert.equal(b.shares, 4);
-  assert.equal(b.pl, (115 - 102) * 4);   // 52
-  assert.equal(l.shares, -4);
-  assert.equal(l.pl, -52);
-  assert.equal(b.pl + l.pl, 0, 'zero sum against the house at a flat print');
+  assert.equal(b.shares, 5);
+  assert.equal(b.pl, (115 - 102) * 5);   // 65
+  assert.equal(l.shares, -3);
+  assert.equal(l.pl, -39);
+  // Not zero-sum: the house is short the 2 it had to supply, and wears the loss.
+  assert.equal(b.pl + l.pl, (115 - 102) * 2);
 
   // Round 2 to the buzzer.
   for (const p of players) {

--- a/mooncoin/server/game.test.js
+++ b/mooncoin/server/game.test.js
@@ -1,0 +1,290 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  createGame, addPlayer, removePlayer, startGame, submitOrder, confirmOrder,
+  submitCards, confirmCards, lockRoll, forceGate, standings, publicState,
+  privateState, updateConfig, resetGame, rollStep,
+} from './game.js';
+
+// Deterministic dice so a "random" game is reproducible.
+const fixedRng = (seq) => { let i = 0; return () => seq[i++ % seq.length]; };
+
+function tableOf(names, config) {
+  const g = createGame('TEST', config);
+  const players = names.map((n) => addPlayer(g, n));
+  startGame(g, fixedRng([0.5]));
+  return { g, players };
+}
+
+function roll(g, values) {
+  for (const v of values) lockRoll(g, Math.random, v);
+}
+
+// --- Seating ---------------------------------------------------------------
+
+test('players take sequential seats', () => {
+  const g = createGame('TEST');
+  const a = addPlayer(g, 'kris');
+  const b = addPlayer(g, 'sam');
+  assert.equal(a.seat, 1);
+  assert.equal(b.seat, 2);
+  assert.equal(a.name, 'KRIS');   // names normalise to the terminal's caps
+});
+
+test('duplicate names are refused', () => {
+  const g = createGame('TEST');
+  addPlayer(g, 'kris');
+  assert.throws(() => addPlayer(g, 'KRIS'), /already seated/);
+});
+
+test('table caps at ten seats', () => {
+  const g = createGame('TEST');
+  for (let i = 0; i < 10; i++) addPlayer(g, `p${i}`);
+  assert.throws(() => addPlayer(g, 'eleven'), /full/);
+});
+
+test('leaving the lobby renumbers the seats', () => {
+  const g = createGame('TEST');
+  const a = addPlayer(g, 'a');
+  addPlayer(g, 'b');
+  const c = addPlayer(g, 'c');
+  removePlayer(g, a.id);
+  assert.equal(g.players[0].name, 'B');
+  assert.equal(g.players[0].seat, 1);
+  assert.equal(c.seat, 2);
+});
+
+test('nobody joins mid-game', () => {
+  const { g } = tableOf(['a', 'b']);
+  assert.throws(() => addPlayer(g, 'latecomer'), /under way/);
+});
+
+// --- Dealing ---------------------------------------------------------------
+
+test('starting deals a full hand to every seat', () => {
+  const { g, players } = tableOf(['a', 'b', 'c']);
+  for (const p of players) {
+    const h = g.players.find((x) => x.id === p.id).hand;
+    assert.equal(h.up + h.down + h.multiply + h.add, g.config.cardQty);
+  }
+  assert.equal(g.phase, 'orders');
+  assert.equal(g.round, 1);
+  assert.equal(g.mark, 100);
+});
+
+test('config that oversubscribes the deck is refused', () => {
+  const g = createGame('TEST');
+  for (let i = 0; i < 10; i++) addPlayer(g, `p${i}`);
+  assert.throws(() => updateConfig(g, { cardQty: 11 }), /exceeds the 100-card deck/);
+  assert.doesNotThrow(() => updateConfig(g, { cardQty: 10 }));
+});
+
+// --- Order gate ------------------------------------------------------------
+
+test('the gate trips only when the last player confirms', () => {
+  const { g, players } = tableOf(['a', 'b']);
+  const [a, b] = players;
+
+  submitOrder(g, a.id, { qty: 5, type: 'MARKET' });
+  confirmOrder(g, a.id);
+  assert.equal(g.phase, 'orders', 'still waiting on b');
+
+  submitOrder(g, b.id, { qty: -5, type: 'LIMIT' });
+  confirmOrder(g, b.id);
+  assert.equal(g.phase, 'cards', 'gate tripped');
+});
+
+test('submitting is not committing', () => {
+  const { g, players } = tableOf(['a', 'b']);
+  const [a, b] = players;
+
+  submitOrder(g, a.id, { qty: 50, type: 'MARKET' });   // typed, never confirmed
+  submitOrder(g, b.id, { qty: 5, type: 'MARKET' });
+  confirmOrder(g, b.id);
+
+  forceGate(g);   // host gives up waiting on a
+
+  assert.equal(g.phase, 'cards');
+  assert.equal(g.reveal.imbalance, 5, 'only b traded');
+  assert.equal(g.players.find((p) => p.id === a.id).fills.length, 0);
+});
+
+test('a confirmed order cannot be rewritten', () => {
+  const { g, players } = tableOf(['a', 'b']);
+  submitOrder(g, players[0].id, { qty: 1, type: 'MARKET' });
+  confirmOrder(g, players[0].id);
+  assert.throws(() => submitOrder(g, players[0].id, { qty: 99, type: 'MARKET' }), /already confirmed/);
+});
+
+test('bad orders are rejected', () => {
+  const { g, players } = tableOf(['a', 'b']);
+  const id = players[0].id;
+  assert.throws(() => submitOrder(g, id, { qty: 'lots', type: 'MARKET' }), /must be a number/);
+  assert.throws(() => submitOrder(g, id, { qty: 5, type: 'STOP' }), /LIMIT or MARKET/);
+});
+
+// --- Cards gate ------------------------------------------------------------
+
+test('cards cannot exceed the hand', () => {
+  const { g, players } = tableOf(['a', 'b']);
+  for (const p of players) {
+    submitOrder(g, p.id, { qty: 0, type: 'LIMIT' });
+    confirmOrder(g, p.id);
+  }
+  const me = g.players[0];
+  assert.throws(
+    () => submitCards(g, me.id, { up: me.hand.up + 1 }),
+    /card\(s\) in hand/
+  );
+});
+
+test('confirming spends cards; declining keeps them', () => {
+  const { g, players } = tableOf(['a', 'b']);
+  for (const p of players) {
+    submitOrder(g, p.id, { qty: 0, type: 'LIMIT' });
+    confirmOrder(g, p.id);
+  }
+
+  const a = g.players[0];
+  const b = g.players[1];
+  const aUpBefore = a.hand.up;
+  const bUpBefore = b.hand.up;
+
+  if (aUpBefore > 0) submitCards(g, a.id, { up: 1 });
+  confirmCards(g, a.id);
+
+  if (bUpBefore > 0) submitCards(g, b.id, { up: 1 });   // submitted but never confirmed
+  forceGate(g);
+
+  assert.equal(a.hand.up, Math.max(0, aUpBefore - (aUpBefore > 0 ? 1 : 0)));
+  assert.equal(b.hand.up, bUpBefore, 'unconfirmed cards stay in hand');
+});
+
+// --- Dice and settlement ---------------------------------------------------
+
+test('four dice settle the round', () => {
+  const { g, players } = tableOf(['a', 'b']);
+  for (const p of players) {
+    submitOrder(g, p.id, { qty: 0, type: 'LIMIT' });
+    confirmOrder(g, p.id);
+  }
+  for (const p of players) confirmCards(g, p.id);
+
+  assert.equal(g.phase, 'rolling');
+  assert.equal(rollStep(g), 0);
+
+  lockRoll(g, Math.random, 4);
+  assert.equal(rollStep(g), 1);
+  lockRoll(g, Math.random, 5);
+  lockRoll(g, Math.random, 5);
+  assert.equal(g.phase, 'rolling', 'not settled until the fourth');
+  lockRoll(g, Math.random, 3);
+
+  // The spreadsheet's own round 1: dice 4/5/5/3 -> +15, mark 115.
+  assert.equal(g.mark, 115);
+  assert.equal(g.history[0].chg, 15);
+  assert.equal(g.history[0].type, 'MULTIPLY');
+  assert.equal(g.round, 2);
+  assert.equal(g.phase, 'orders');
+});
+
+test('a fifth die is refused', () => {
+  const { g, players } = tableOf(['a', 'b'], { maxRounds: 1 });
+  for (const p of players) {
+    submitOrder(g, p.id, { qty: 0, type: 'LIMIT' });
+    confirmOrder(g, p.id);
+  }
+  for (const p of players) confirmCards(g, p.id);
+  roll(g, [4, 5, 5, 3]);
+  assert.equal(g.phase, 'complete');
+  assert.throws(() => lockRoll(g, Math.random, 6), /Not rolling/);
+});
+
+// --- A whole game end to end ----------------------------------------------
+
+test('a full game settles P/L consistently', () => {
+  const { g, players } = tableOf(['buyer', 'seller'], { maxRounds: 2 });
+  const [buyer, seller] = players;
+
+  // Round 1: buyer lifts 4 at market, seller rests 4.
+  submitOrder(g, buyer.id, { qty: 4, type: 'MARKET' });
+  confirmOrder(g, buyer.id);
+  submitOrder(g, seller.id, { qty: -4, type: 'LIMIT' });
+  confirmOrder(g, seller.id);
+
+  assert.equal(g.reveal.price, 102);     // 100 + ceil(sqrt(4))
+  for (const p of players) confirmCards(g, p.id);
+  roll(g, [4, 5, 5, 3]);                 // +15 -> mark 115
+
+  assert.equal(g.mark, 115);
+  const s = standings(g);
+  const b = s.find((x) => x.name === 'BUYER');
+  const l = s.find((x) => x.name === 'SELLER');
+  assert.equal(b.shares, 4);
+  assert.equal(b.pl, (115 - 102) * 4);   // 52
+  assert.equal(l.shares, -4);
+  assert.equal(l.pl, -52);
+  assert.equal(b.pl + l.pl, 0, 'zero sum against the house at a flat print');
+
+  // Round 2 to the buzzer.
+  for (const p of players) {
+    submitOrder(g, p.id, { qty: 0, type: 'LIMIT' });
+    confirmOrder(g, p.id);
+  }
+  for (const p of players) confirmCards(g, p.id);
+  roll(g, [1, 1, 2, 2]);                 // trend down, ADD -> -4
+
+  assert.equal(g.phase, 'complete');
+  assert.equal(g.mark, 111);
+  assert.equal(g.history.length, 2);
+});
+
+// --- Information hiding ----------------------------------------------------
+
+test('orders stay hidden until the gate trips', () => {
+  const { g, players } = tableOf(['a', 'b']);
+  submitOrder(g, players[0].id, { qty: 999, type: 'MARKET' });
+  confirmOrder(g, players[0].id);
+
+  const pub = publicState(g);
+  assert.equal(pub.reveal, null, 'no book leaks mid-collection');
+  assert.deepEqual(pub.awaitingOrders, ['B'], 'who is holding things up is fair game');
+  assert.ok(!JSON.stringify(pub).includes('999'), 'the quantity itself must not leak');
+});
+
+test('cards stay hidden until the cards gate trips', () => {
+  const { g, players } = tableOf(['a', 'b']);
+  for (const p of players) {
+    submitOrder(g, p.id, { qty: 0, type: 'LIMIT' });
+    confirmOrder(g, p.id);
+  }
+  submitCards(g, players[0].id, { up: 1 });
+  confirmCards(g, players[0].id);
+
+  assert.equal(publicState(g).net, null);
+  for (const p of players) confirmCards(g, p.id);
+  assert.ok(publicState(g).net, 'revealed once everyone is in');
+});
+
+test('a player sees their own hand and nobody else\'s', () => {
+  const { g, players } = tableOf(['a', 'b']);
+  const view = privateState(g, players[0].id);
+  assert.equal(view.me.name, 'A');
+  assert.equal(view.me.hand.up + view.me.hand.down + view.me.hand.multiply + view.me.hand.add, 10);
+  assert.equal(privateState(g, 'nobody'), null);
+});
+
+// --- Reset -----------------------------------------------------------------
+
+test('reset returns the table to the lobby with seats intact', () => {
+  const { g, players } = tableOf(['a', 'b']);
+  submitOrder(g, players[0].id, { qty: 5, type: 'MARKET' });
+  confirmOrder(g, players[0].id);
+  resetGame(g);
+
+  assert.equal(g.phase, 'lobby');
+  assert.equal(g.round, 0);
+  assert.equal(g.mark, 100);
+  assert.equal(g.players.length, 2, 'players keep their seats');
+  assert.equal(g.players[0].fills.length, 0);
+});

--- a/mooncoin/server/handler.js
+++ b/mooncoin/server/handler.js
@@ -1,0 +1,150 @@
+/**
+ * The API, as one function.
+ *
+ * Deliberately transport-agnostic: takes a plain request description and returns
+ * a plain response, so the Vercel serverless entry and the local dev server run
+ * identical code.
+ *
+ *   GET  /api/game?code=ABCD&token=…   poll for state
+ *   POST /api/game   { action, code, token, … }
+ *
+ * Every mutating action returns the fresh state, so whoever acted sees the
+ * result immediately instead of waiting for the next poll tick.
+ */
+
+import { randomBytes } from 'node:crypto';
+import * as G from './game.js';
+import * as store from './store.js';
+
+const token = () => randomBytes(16).toString('hex');
+
+const ok = (body) => ({ status: 200, body });
+const bad = (status, message) => ({ status, body: { error: message } });
+
+/** Who is asking, derived from the token alone. */
+function identify(game, tok) {
+  if (tok && tok === game.hostToken) return { role: 'host', player: null };
+  const player = tok ? game.players.find((p) => p.token === tok) : null;
+  if (player) return { role: 'player', player };
+  return { role: 'dashboard', player: null };
+}
+
+function view(game, tok) {
+  const { role, player } = identify(game, tok);
+  const body = {
+    role,
+    state: G.publicState(game),
+    // Surfaced so the client can warn rather than misbehave: without Redis,
+    // serverless requests can land on different instances holding different games.
+    ephemeral: !store.configured,
+  };
+  if (player) Object.assign(body, G.privateState(game, player.id));
+  return body;
+}
+
+/** Actions a seated player may take, and the host may not. */
+const PLAYER_ACTIONS = {
+  order: (game, p, msg) => G.submitOrder(game, p.id, { qty: msg.qty, type: msg.orderType }),
+  confirmOrder: (game, p) => G.confirmOrder(game, p.id),
+  unconfirmOrder: (game, p) => G.unconfirmOrder(game, p.id),
+  cards: (game, p, msg) => G.submitCards(game, p.id, msg.cards),
+  confirmCards: (game, p) => G.confirmCards(game, p.id),
+  unconfirmCards: (game, p) => G.unconfirmCards(game, p.id),
+  leave: (game, p) => G.removePlayer(game, p.id),
+};
+
+/** Actions only the host token unlocks. */
+const HOST_ACTIONS = {
+  start: (game) => G.startGame(game),
+  force: (game) => G.forceGate(game),
+  reset: (game) => G.resetGame(game),
+  roll: (game) => G.lockRoll(game),
+  config: (game, msg) => G.updateConfig(game, msg.config ?? {}),
+  kick: (game, msg) => G.removePlayer(game, msg.playerId),
+};
+
+export async function handle({ method, query = {}, body = {} }) {
+  try {
+    if (method === 'GET') return await handleGet(query);
+    if (method === 'POST') return await handlePost(body);
+    return bad(405, 'Method not allowed');
+  } catch (err) {
+    // Game-rule violations are the caller's problem, not a server fault.
+    return bad(400, err.message);
+  }
+}
+
+async function handleGet(query) {
+  const code = String(query.code || '').toUpperCase();
+  if (!code) return bad(400, 'Room code required');
+
+  const game = await store.load(code);
+  if (!game) return bad(404, `No table with code ${code}`);
+
+  return ok(view(game, query.token));
+}
+
+async function handlePost(body) {
+  const action = body.action;
+  if (action === 'create') return createTable(body);
+  if (action === 'join') return joinTable(body);
+
+  const code = String(body.code || '').toUpperCase();
+  if (!code) return bad(400, 'Room code required');
+
+  const result = await store.mutate(code, (game) => {
+    const { role, player } = identify(game, body.token);
+    game.lastActivity = Date.now();
+
+    if (PLAYER_ACTIONS[action]) {
+      if (!player) throw new Error('Not seated at this table');
+      PLAYER_ACTIONS[action](game, player, body);
+    } else if (HOST_ACTIONS[action]) {
+      if (role !== 'host') throw new Error('Host controls only');
+      HOST_ACTIONS[action](game, body);
+    } else {
+      throw new Error(`Unknown action: ${action}`);
+    }
+
+    return view(game, body.token);
+  });
+
+  return ok(result);
+}
+
+async function createTable(body) {
+  let code;
+  do { code = G.makeRoomCode(); } while (await store.exists(code));
+
+  const game = G.createGame(code, body.config ?? {});
+  game.hostToken = token();
+  game.lastActivity = Date.now();
+  await store.save(game);
+
+  return ok({ code, hostToken: game.hostToken, ephemeral: !store.configured });
+}
+
+async function joinTable(body) {
+  const code = String(body.code || '').toUpperCase();
+  if (!code) return bad(400, 'Room code required');
+
+  const result = await store.mutate(code, (game) => {
+    game.lastActivity = Date.now();
+
+    // A known token is a reconnect, not a new seat.
+    const existing = body.token
+      ? game.players.find((p) => p.token === body.token)
+      : null;
+
+    const player = existing ?? Object.assign(G.addPlayer(game, body.name), { token: token() });
+    player.connected = true;
+
+    return {
+      playerId: player.id,
+      playerToken: player.token,
+      ...view(game, player.token),
+    };
+  });
+
+  return ok(result);
+}

--- a/mooncoin/server/index.js
+++ b/mooncoin/server/index.js
@@ -1,0 +1,311 @@
+/**
+ * Mooncoin server: static files, a small JSON API for creating tables, and a
+ * WebSocket per connected screen.
+ *
+ * Three kinds of screen connect to the same room:
+ *   player    — private hand, order ticket, blotter
+ *   dashboard — the shared read-only display
+ *   host      — the dashboard plus the controls that drive the round
+ */
+
+import { createServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { extname, join, normalize, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { randomBytes } from 'node:crypto';
+import { WebSocketServer } from 'ws';
+
+import * as G from './game.js';
+import { Store } from './store.js';
+
+const ROOT = resolve(fileURLToPath(new URL('../', import.meta.url)));
+const PUBLIC_DIR = join(ROOT, 'public');
+const PORT = Number(process.env.PORT) || 3000;
+const DATA_FILE = process.env.MOONCOIN_DATA ?? join(ROOT, '.data', 'games.json');
+
+const store = new Store(DATA_FILE);
+
+/** code -> Set<ws>.  Sockets carry their own role/identity on ws.ctx. */
+const rooms = new Map();
+
+const MIME = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.ico': 'image/x-icon',
+  '.png': 'image/png',
+  '.woff2': 'font/woff2',
+};
+
+const token = () => randomBytes(16).toString('hex');
+
+// ---------------------------------------------------------------------------
+// HTTP
+// ---------------------------------------------------------------------------
+
+const server = createServer(async (req, res) => {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+
+  if (url.pathname === '/api/games' && req.method === 'POST') {
+    return createTable(req, res);
+  }
+  if (url.pathname.startsWith('/api/games/') && req.method === 'GET') {
+    const game = store.get(url.pathname.split('/')[3]?.toUpperCase());
+    return json(res, game ? 200 : 404, game
+      ? { exists: true, phase: game.phase, seated: game.players.length, round: game.round }
+      : { exists: false });
+  }
+  if (url.pathname.startsWith('/api/')) return json(res, 404, { error: 'Not found' });
+
+  return serveStatic(url.pathname, res);
+});
+
+async function createTable(req, res) {
+  let body = '';
+  for await (const chunk of req) {
+    body += chunk;
+    if (body.length > 4096) return json(res, 413, { error: 'Payload too large' });
+  }
+
+  let config = {};
+  try {
+    config = body ? JSON.parse(body) : {};
+  } catch {
+    return json(res, 400, { error: 'Invalid JSON' });
+  }
+
+  let code;
+  do { code = G.makeRoomCode(); } while (store.get(code));
+
+  const game = G.createGame(code, config);
+  game.hostToken = token();
+  game.lastActivity = Date.now();
+  store.set(game);
+
+  console.log(`[room ${code}] created`);
+  return json(res, 201, { code, hostToken: game.hostToken });
+}
+
+async function serveStatic(pathname, res) {
+  const rel = normalize(decodeURIComponent(pathname)).replace(/^(\.\.[/\\])+/, '');
+  let file = join(PUBLIC_DIR, rel);
+
+  // Everything that is not a real asset renders the app shell, so /ABCD works
+  // as a shareable join link.
+  if (!extname(file)) file = join(PUBLIC_DIR, 'index.html');
+  if (!file.startsWith(PUBLIC_DIR)) return json(res, 403, { error: 'Forbidden' });
+
+  try {
+    const data = await readFile(file);
+    res.writeHead(200, {
+      'Content-Type': MIME[extname(file)] ?? 'application/octet-stream',
+      'Cache-Control': extname(file) === '.html' ? 'no-cache' : 'max-age=300',
+    });
+    res.end(data);
+  } catch {
+    res.writeHead(404, { 'Content-Type': 'text/plain' });
+    res.end('Not found');
+  }
+}
+
+function json(res, status, body) {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+// ---------------------------------------------------------------------------
+// WebSockets
+// ---------------------------------------------------------------------------
+
+const wss = new WebSocketServer({ server, path: '/ws' });
+
+wss.on('connection', (ws) => {
+  ws.ctx = { role: null, code: null, playerId: null };
+  ws.isAlive = true;
+  ws.on('pong', () => { ws.isAlive = true; });
+
+  ws.on('message', (raw) => {
+    let msg;
+    try {
+      msg = JSON.parse(raw);
+    } catch {
+      return send(ws, { type: 'error', message: 'Malformed message' });
+    }
+    try {
+      handle(ws, msg);
+    } catch (err) {
+      send(ws, { type: 'error', message: err.message });
+    }
+  });
+
+  ws.on('close', () => {
+    const { code, playerId } = ws.ctx;
+    rooms.get(code)?.delete(ws);
+    if (!playerId) return;
+    const game = store.get(code);
+    const player = game?.players.find((p) => p.id === playerId);
+    if (player) {
+      player.connected = false;
+      store.touch();
+      broadcast(code);
+    }
+  });
+});
+
+// Drop sockets that stopped answering rather than leaving them in the room set.
+const heartbeat = setInterval(() => {
+  for (const ws of wss.clients) {
+    if (!ws.isAlive) { ws.terminate(); continue; }
+    ws.isAlive = false;
+    ws.ping();
+  }
+}, 30000);
+heartbeat.unref();
+
+function handle(ws, msg) {
+  if (msg.type === 'hello') return hello(ws, msg);
+
+  const game = requireGame(ws);
+  game.lastActivity = Date.now();
+  const { role, playerId } = ws.ctx;
+
+  const playerActions = {
+    order: () => G.submitOrder(game, playerId, { qty: msg.qty, type: msg.orderType }),
+    confirmOrder: () => G.confirmOrder(game, playerId),
+    unconfirmOrder: () => G.unconfirmOrder(game, playerId),
+    cards: () => G.submitCards(game, playerId, msg.cards),
+    confirmCards: () => G.confirmCards(game, playerId),
+    unconfirmCards: () => G.unconfirmCards(game, playerId),
+    leave: () => G.removePlayer(game, playerId),
+  };
+
+  const hostActions = {
+    start: () => G.startGame(game),
+    force: () => G.forceGate(game),
+    reset: () => G.resetGame(game),
+    config: () => G.updateConfig(game, msg.config ?? {}),
+    kick: () => G.removePlayer(game, msg.playerId),
+    roll: () => {
+      const result = G.lockRoll(game);
+      const step = G.rollStep(game);
+      broadcastRaw(game.code, {
+        type: 'die',
+        index: step - 1,
+        value: game.dice[step - 1],
+        settled: result.settled,
+      });
+    },
+  };
+
+  if (playerActions[msg.type]) {
+    if (role !== 'player') throw new Error('Not seated at this table');
+    playerActions[msg.type]();
+  } else if (hostActions[msg.type]) {
+    if (role !== 'host') throw new Error('Host controls only');
+    hostActions[msg.type]();
+  } else {
+    throw new Error(`Unknown action: ${msg.type}`);
+  }
+
+  store.touch();
+  broadcast(game.code);
+}
+
+function hello(ws, msg) {
+  const code = String(msg.code || '').toUpperCase();
+  const game = store.get(code);
+  if (!game) throw new Error(`No table with code ${code}`);
+
+  game.lastActivity = Date.now();
+  ws.ctx.code = code;
+
+  if (msg.role === 'host') {
+    if (msg.hostToken !== game.hostToken) throw new Error('Bad host token');
+    ws.ctx.role = 'host';
+  } else if (msg.role === 'dashboard') {
+    ws.ctx.role = 'dashboard';
+  } else if (msg.role === 'player') {
+    const player = msg.playerToken
+      ? game.players.find((p) => p.token === msg.playerToken)
+      : null;
+
+    if (player) {
+      // Reconnect — same seat, same hand, same blotter.
+      player.connected = true;
+      ws.ctx.playerId = player.id;
+      console.log(`[room ${code}] ${player.name} reconnected`);
+    } else {
+      const seated = G.addPlayer(game, msg.name);
+      seated.token = token();
+      seated.connected = true;
+      ws.ctx.playerId = seated.id;
+      console.log(`[room ${code}] ${seated.name} joined seat ${seated.seat}`);
+    }
+
+    ws.ctx.role = 'player';
+    const me = game.players.find((p) => p.id === ws.ctx.playerId);
+    send(ws, { type: 'seated', playerId: me.id, playerToken: me.token, name: me.name, seat: me.seat });
+  } else {
+    throw new Error('Unknown role');
+  }
+
+  if (!rooms.has(code)) rooms.set(code, new Set());
+  rooms.get(code).add(ws);
+
+  store.touch();
+  broadcast(code);
+}
+
+function requireGame(ws) {
+  if (!ws.ctx.code) throw new Error('Say hello first');
+  const game = store.get(ws.ctx.code);
+  if (!game) throw new Error('Table is gone');
+  return game;
+}
+
+// ---------------------------------------------------------------------------
+// Fan-out
+// ---------------------------------------------------------------------------
+
+function send(ws, payload) {
+  if (ws.readyState === ws.OPEN) ws.send(JSON.stringify(payload));
+}
+
+function broadcastRaw(code, payload) {
+  for (const ws of rooms.get(code) ?? []) send(ws, payload);
+}
+
+/**
+ * Push state to every screen in the room. Each player's socket gets the shared
+ * view plus its own private slice; dashboards and the host get the shared view
+ * only, so a hand can never arrive at a screen not entitled to it.
+ */
+function broadcast(code) {
+  const game = store.get(code);
+  if (!game) return;
+  const shared = G.publicState(game);
+
+  for (const ws of rooms.get(code) ?? []) {
+    const payload = { type: 'state', role: ws.ctx.role, state: shared };
+    if (ws.ctx.role === 'player') {
+      const priv = G.privateState(game, ws.ctx.playerId);
+      if (priv) Object.assign(payload, priv);
+    }
+    send(ws, payload);
+  }
+}
+
+// ---------------------------------------------------------------------------
+
+setInterval(() => store.sweep(), 60 * 60 * 1000).unref();
+
+process.on('SIGTERM', () => { store.flush(); server.close(() => process.exit(0)); });
+process.on('SIGINT', () => { store.flush(); server.close(() => process.exit(0)); });
+
+server.listen(PORT, () => {
+  console.log(`Mooncoin terminal listening on http://localhost:${PORT}`);
+});
+
+export { server, store };

--- a/mooncoin/server/index.js
+++ b/mooncoin/server/index.js
@@ -1,32 +1,21 @@
 /**
- * Mooncoin server: static files, a small JSON API for creating tables, and a
- * WebSocket per connected screen.
+ * Local dev server.
  *
- * Three kinds of screen connect to the same room:
- *   player    — private hand, order ticket, blotter
- *   dashboard — the shared read-only display
- *   host      — the dashboard plus the controls that drive the round
+ * Serves public/ and routes /api/game to the same handler the Vercel function
+ * calls, so what runs on your machine is what runs in production.
  */
 
 import { createServer } from 'node:http';
 import { readFile } from 'node:fs/promises';
 import { extname, join, normalize, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { randomBytes } from 'node:crypto';
-import { WebSocketServer } from 'ws';
 
-import * as G from './game.js';
-import { Store } from './store.js';
+import { handle } from './handler.js';
+import { configured } from './store.js';
 
 const ROOT = resolve(fileURLToPath(new URL('../', import.meta.url)));
 const PUBLIC_DIR = join(ROOT, 'public');
 const PORT = Number(process.env.PORT) || 3000;
-const DATA_FILE = process.env.MOONCOIN_DATA ?? join(ROOT, '.data', 'games.json');
-
-const store = new Store(DATA_FILE);
-
-/** code -> Set<ws>.  Sockets carry their own role/identity on ws.ctx. */
-const rooms = new Map();
 
 const MIME = {
   '.html': 'text/html; charset=utf-8',
@@ -39,61 +28,41 @@ const MIME = {
   '.woff2': 'font/woff2',
 };
 
-const token = () => randomBytes(16).toString('hex');
-
-// ---------------------------------------------------------------------------
-// HTTP
-// ---------------------------------------------------------------------------
-
 const server = createServer(async (req, res) => {
   const url = new URL(req.url, `http://${req.headers.host}`);
 
-  if (url.pathname === '/api/games' && req.method === 'POST') {
-    return createTable(req, res);
-  }
-  if (url.pathname.startsWith('/api/games/') && req.method === 'GET') {
-    const game = store.get(url.pathname.split('/')[3]?.toUpperCase());
-    return json(res, game ? 200 : 404, game
-      ? { exists: true, phase: game.phase, seated: game.players.length, round: game.round }
-      : { exists: false });
-  }
+  if (url.pathname === '/api/game') return api(req, res, url);
   if (url.pathname.startsWith('/api/')) return json(res, 404, { error: 'Not found' });
 
   return serveStatic(url.pathname, res);
 });
 
-async function createTable(req, res) {
-  let body = '';
-  for await (const chunk of req) {
-    body += chunk;
-    if (body.length > 4096) return json(res, 413, { error: 'Payload too large' });
+async function api(req, res, url) {
+  let body = {};
+  if (req.method === 'POST') {
+    let raw = '';
+    for await (const chunk of req) {
+      raw += chunk;
+      if (raw.length > 65536) return json(res, 413, { error: 'Payload too large' });
+    }
+    try { body = raw ? JSON.parse(raw) : {}; }
+    catch { return json(res, 400, { error: 'Invalid JSON' }); }
   }
 
-  let config = {};
-  try {
-    config = body ? JSON.parse(body) : {};
-  } catch {
-    return json(res, 400, { error: 'Invalid JSON' });
-  }
-
-  let code;
-  do { code = G.makeRoomCode(); } while (store.get(code));
-
-  const game = G.createGame(code, config);
-  game.hostToken = token();
-  game.lastActivity = Date.now();
-  store.set(game);
-
-  console.log(`[room ${code}] created`);
-  return json(res, 201, { code, hostToken: game.hostToken });
+  const { status, body: payload } = await handle({
+    method: req.method,
+    query: Object.fromEntries(url.searchParams),
+    body,
+  });
+  return json(res, status, payload);
 }
 
 async function serveStatic(pathname, res) {
   const rel = normalize(decodeURIComponent(pathname)).replace(/^(\.\.[/\\])+/, '');
   let file = join(PUBLIC_DIR, rel);
 
-  // Everything that is not a real asset renders the app shell, so /ABCD works
-  // as a shareable join link.
+  // Anything without an extension renders the app shell, so /ABCD is a
+  // shareable join link. Mirrors the rewrite in vercel.json.
   if (!extname(file)) file = join(PUBLIC_DIR, 'index.html');
   if (!file.startsWith(PUBLIC_DIR)) return json(res, 403, { error: 'Forbidden' });
 
@@ -111,201 +80,15 @@ async function serveStatic(pathname, res) {
 }
 
 function json(res, status, body) {
-  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.writeHead(status, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' });
   res.end(JSON.stringify(body));
 }
 
-// ---------------------------------------------------------------------------
-// WebSockets
-// ---------------------------------------------------------------------------
-
-const wss = new WebSocketServer({ server, path: '/ws' });
-
-wss.on('connection', (ws) => {
-  ws.ctx = { role: null, code: null, playerId: null };
-  ws.isAlive = true;
-  ws.on('pong', () => { ws.isAlive = true; });
-
-  ws.on('message', (raw) => {
-    let msg;
-    try {
-      msg = JSON.parse(raw);
-    } catch {
-      return send(ws, { type: 'error', message: 'Malformed message' });
-    }
-    try {
-      handle(ws, msg);
-    } catch (err) {
-      send(ws, { type: 'error', message: err.message });
-    }
-  });
-
-  ws.on('close', () => {
-    const { code, playerId } = ws.ctx;
-    rooms.get(code)?.delete(ws);
-    if (!playerId) return;
-    const game = store.get(code);
-    const player = game?.players.find((p) => p.id === playerId);
-    if (player) {
-      player.connected = false;
-      store.touch();
-      broadcast(code);
-    }
-  });
-});
-
-// Drop sockets that stopped answering rather than leaving them in the room set.
-const heartbeat = setInterval(() => {
-  for (const ws of wss.clients) {
-    if (!ws.isAlive) { ws.terminate(); continue; }
-    ws.isAlive = false;
-    ws.ping();
-  }
-}, 30000);
-heartbeat.unref();
-
-function handle(ws, msg) {
-  if (msg.type === 'hello') return hello(ws, msg);
-
-  const game = requireGame(ws);
-  game.lastActivity = Date.now();
-  const { role, playerId } = ws.ctx;
-
-  const playerActions = {
-    order: () => G.submitOrder(game, playerId, { qty: msg.qty, type: msg.orderType }),
-    confirmOrder: () => G.confirmOrder(game, playerId),
-    unconfirmOrder: () => G.unconfirmOrder(game, playerId),
-    cards: () => G.submitCards(game, playerId, msg.cards),
-    confirmCards: () => G.confirmCards(game, playerId),
-    unconfirmCards: () => G.unconfirmCards(game, playerId),
-    leave: () => G.removePlayer(game, playerId),
-  };
-
-  const hostActions = {
-    start: () => G.startGame(game),
-    force: () => G.forceGate(game),
-    reset: () => G.resetGame(game),
-    config: () => G.updateConfig(game, msg.config ?? {}),
-    kick: () => G.removePlayer(game, msg.playerId),
-    roll: () => {
-      const result = G.lockRoll(game);
-      const step = G.rollStep(game);
-      broadcastRaw(game.code, {
-        type: 'die',
-        index: step - 1,
-        value: game.dice[step - 1],
-        settled: result.settled,
-      });
-    },
-  };
-
-  if (playerActions[msg.type]) {
-    if (role !== 'player') throw new Error('Not seated at this table');
-    playerActions[msg.type]();
-  } else if (hostActions[msg.type]) {
-    if (role !== 'host') throw new Error('Host controls only');
-    hostActions[msg.type]();
-  } else {
-    throw new Error(`Unknown action: ${msg.type}`);
-  }
-
-  store.touch();
-  broadcast(game.code);
-}
-
-function hello(ws, msg) {
-  const code = String(msg.code || '').toUpperCase();
-  const game = store.get(code);
-  if (!game) throw new Error(`No table with code ${code}`);
-
-  game.lastActivity = Date.now();
-  ws.ctx.code = code;
-
-  if (msg.role === 'host') {
-    if (msg.hostToken !== game.hostToken) throw new Error('Bad host token');
-    ws.ctx.role = 'host';
-  } else if (msg.role === 'dashboard') {
-    ws.ctx.role = 'dashboard';
-  } else if (msg.role === 'player') {
-    const player = msg.playerToken
-      ? game.players.find((p) => p.token === msg.playerToken)
-      : null;
-
-    if (player) {
-      // Reconnect — same seat, same hand, same blotter.
-      player.connected = true;
-      ws.ctx.playerId = player.id;
-      console.log(`[room ${code}] ${player.name} reconnected`);
-    } else {
-      const seated = G.addPlayer(game, msg.name);
-      seated.token = token();
-      seated.connected = true;
-      ws.ctx.playerId = seated.id;
-      console.log(`[room ${code}] ${seated.name} joined seat ${seated.seat}`);
-    }
-
-    ws.ctx.role = 'player';
-    const me = game.players.find((p) => p.id === ws.ctx.playerId);
-    send(ws, { type: 'seated', playerId: me.id, playerToken: me.token, name: me.name, seat: me.seat });
-  } else {
-    throw new Error('Unknown role');
-  }
-
-  if (!rooms.has(code)) rooms.set(code, new Set());
-  rooms.get(code).add(ws);
-
-  store.touch();
-  broadcast(code);
-}
-
-function requireGame(ws) {
-  if (!ws.ctx.code) throw new Error('Say hello first');
-  const game = store.get(ws.ctx.code);
-  if (!game) throw new Error('Table is gone');
-  return game;
-}
-
-// ---------------------------------------------------------------------------
-// Fan-out
-// ---------------------------------------------------------------------------
-
-function send(ws, payload) {
-  if (ws.readyState === ws.OPEN) ws.send(JSON.stringify(payload));
-}
-
-function broadcastRaw(code, payload) {
-  for (const ws of rooms.get(code) ?? []) send(ws, payload);
-}
-
-/**
- * Push state to every screen in the room. Each player's socket gets the shared
- * view plus its own private slice; dashboards and the host get the shared view
- * only, so a hand can never arrive at a screen not entitled to it.
- */
-function broadcast(code) {
-  const game = store.get(code);
-  if (!game) return;
-  const shared = G.publicState(game);
-
-  for (const ws of rooms.get(code) ?? []) {
-    const payload = { type: 'state', role: ws.ctx.role, state: shared };
-    if (ws.ctx.role === 'player') {
-      const priv = G.privateState(game, ws.ctx.playerId);
-      if (priv) Object.assign(payload, priv);
-    }
-    send(ws, payload);
-  }
-}
-
-// ---------------------------------------------------------------------------
-
-setInterval(() => store.sweep(), 60 * 60 * 1000).unref();
-
-process.on('SIGTERM', () => { store.flush(); server.close(() => process.exit(0)); });
-process.on('SIGINT', () => { store.flush(); server.close(() => process.exit(0)); });
-
 server.listen(PORT, () => {
   console.log(`Mooncoin terminal listening on http://localhost:${PORT}`);
+  if (!configured) {
+    console.log('[store] no Redis configured — games live in this process only');
+  }
 });
 
-export { server, store };
+export { server };

--- a/mooncoin/server/store.js
+++ b/mooncoin/server/store.js
@@ -1,88 +1,113 @@
 /**
- * Snapshot persistence.
+ * Game storage.
  *
- * Games are small and short-lived, so the whole set is kept in memory and
- * flushed to one JSON file on a short debounce. That is enough to survive a
- * restart or a redeploy mid-game, which is the only durability this needs.
+ * Serverless functions share no memory, so game state lives in Redis. Talks the
+ * Upstash REST API directly over fetch — no SDK, no dependency — which is what
+ * both the Vercel KV integration and a plain Upstash database expose.
+ *
+ * With no Redis configured it falls back to an in-process Map. That is correct
+ * for local development and for the tests; on serverless it is NOT, because
+ * consecutive requests can land on different instances. `configured` is exported
+ * so the UI can say so out loud rather than behaving strangely.
  */
 
-import { readFileSync, writeFileSync, renameSync, mkdirSync, existsSync } from 'node:fs';
-import { dirname } from 'node:path';
+const URL_ENV = ['KV_REST_API_URL', 'UPSTASH_REDIS_REST_URL', 'REDIS_REST_URL'];
+const TOKEN_ENV = ['KV_REST_API_TOKEN', 'UPSTASH_REDIS_REST_TOKEN', 'REDIS_REST_TOKEN'];
 
-const FLUSH_MS = 250;
-const MAX_AGE_MS = 12 * 60 * 60 * 1000;   // a table abandoned for half a day is done
+const pick = (names) => names.map((n) => process.env[n]).find(Boolean);
 
-export class Store {
-  constructor(path) {
-    this.path = path;
-    this.games = new Map();
-    this.timer = null;
-    this.load();
-  }
+const REST_URL = pick(URL_ENV)?.replace(/\/$/, '');
+const REST_TOKEN = pick(TOKEN_ENV);
 
-  load() {
-    if (!this.path || !existsSync(this.path)) return;
-    try {
-      const raw = JSON.parse(readFileSync(this.path, 'utf8'));
-      for (const game of raw.games ?? []) {
-        // Nobody is connected across a restart, whatever the snapshot claimed.
-        for (const p of game.players) p.connected = false;
-        this.games.set(game.code, game);
-      }
-      this.sweep();
-      console.log(`[store] restored ${this.games.size} game(s) from ${this.path}`);
-    } catch (err) {
-      console.error(`[store] could not read ${this.path}, starting empty:`, err.message);
-    }
-  }
+export const configured = Boolean(REST_URL && REST_TOKEN);
 
-  flush() {
-    if (!this.path) return;
-    try {
-      mkdirSync(dirname(this.path), { recursive: true });
-      const tmp = `${this.path}.tmp`;
-      writeFileSync(tmp, JSON.stringify({ games: [...this.games.values()] }));
-      renameSync(tmp, this.path);   // atomic, so a crash mid-write cannot corrupt it
-    } catch (err) {
-      console.error('[store] flush failed:', err.message);
-    }
-  }
+const TTL_SECONDS = 12 * 60 * 60;   // a table abandoned for half a day is done
+const LOCK_MS = 4000;
+const LOCK_TRIES = 25;
+const LOCK_WAIT_MS = 60;
 
-  /** Coalesce the writes a burst of player actions would otherwise cause. */
-  touch() {
-    if (!this.path || this.timer) return;
-    this.timer = setTimeout(() => {
-      this.timer = null;
-      this.flush();
-    }, FLUSH_MS);
-    this.timer.unref?.();
-  }
+const memory = new Map();
 
-  get(code) {
-    return this.games.get(code);
-  }
+async function command(...args) {
+  const res = await fetch(REST_URL, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${REST_TOKEN}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(args.map(String)),
+  });
+  if (!res.ok) throw new Error(`Redis ${args[0]} failed: ${res.status} ${await res.text()}`);
+  const { result, error } = await res.json();
+  if (error) throw new Error(`Redis ${args[0]}: ${error}`);
+  return result;
+}
 
-  set(game) {
-    this.games.set(game.code, game);
-    this.touch();
+const key = (code) => `mooncoin:game:${code}`;
+const lockKey = (code) => `mooncoin:lock:${code}`;
+
+export async function load(code) {
+  if (!configured) return memory.get(code) ?? null;
+  const raw = await command('GET', key(code));
+  return raw ? JSON.parse(raw) : null;
+}
+
+export async function save(game) {
+  if (!configured) {
+    memory.set(game.code, game);
     return game;
   }
+  await command('SET', key(game.code), JSON.stringify(game), 'EX', TTL_SECONDS);
+  return game;
+}
 
-  delete(code) {
-    const gone = this.games.delete(code);
-    if (gone) this.touch();
-    return gone;
+export async function exists(code) {
+  if (!configured) return memory.has(code);
+  return (await command('EXISTS', key(code))) === 1;
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Run `fn` against the game under an exclusive lock, then persist whatever it
+ * returns. Without this, two players confirming at the same instant would both
+ * read the pre-confirm state and one write would erase the other — which on a
+ * ready-gate means a round that never trips.
+ */
+export async function mutate(code, fn) {
+  if (!configured) {
+    const game = memory.get(code);
+    if (!game) throw new Error(`No table with code ${code}`);
+    const result = await fn(game);
+    memory.set(code, game);
+    return result;
   }
 
-  sweep(now = Date.now()) {
-    let dropped = 0;
-    for (const [code, game] of this.games) {
-      if (now - (game.lastActivity ?? game.createdAt) > MAX_AGE_MS) {
-        this.games.delete(code);
-        dropped++;
-      }
+  const stamp = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  let held = false;
+  for (let i = 0; i < LOCK_TRIES && !held; i++) {
+    held = (await command('SET', lockKey(code), stamp, 'NX', 'PX', LOCK_MS)) !== null;
+    if (!held) await sleep(LOCK_WAIT_MS);
+  }
+  if (!held) throw new Error('Table is busy, try again');
+
+  try {
+    const raw = await command('GET', key(code));
+    if (!raw) throw new Error(`No table with code ${code}`);
+    const game = JSON.parse(raw);
+    const result = await fn(game);
+    await command('SET', key(code), JSON.stringify(game), 'EX', TTL_SECONDS);
+    return result;
+  } finally {
+    // Only release a lock we still own — a slow request whose lock already
+    // expired must not free the next holder's.
+    if ((await command('GET', lockKey(code))) === stamp) {
+      await command('DEL', lockKey(code)).catch(() => {});
     }
-    if (dropped) this.touch();
-    return dropped;
   }
+}
+
+/** Test seam. */
+export function _reset() {
+  memory.clear();
 }

--- a/mooncoin/server/store.js
+++ b/mooncoin/server/store.js
@@ -1,0 +1,88 @@
+/**
+ * Snapshot persistence.
+ *
+ * Games are small and short-lived, so the whole set is kept in memory and
+ * flushed to one JSON file on a short debounce. That is enough to survive a
+ * restart or a redeploy mid-game, which is the only durability this needs.
+ */
+
+import { readFileSync, writeFileSync, renameSync, mkdirSync, existsSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+const FLUSH_MS = 250;
+const MAX_AGE_MS = 12 * 60 * 60 * 1000;   // a table abandoned for half a day is done
+
+export class Store {
+  constructor(path) {
+    this.path = path;
+    this.games = new Map();
+    this.timer = null;
+    this.load();
+  }
+
+  load() {
+    if (!this.path || !existsSync(this.path)) return;
+    try {
+      const raw = JSON.parse(readFileSync(this.path, 'utf8'));
+      for (const game of raw.games ?? []) {
+        // Nobody is connected across a restart, whatever the snapshot claimed.
+        for (const p of game.players) p.connected = false;
+        this.games.set(game.code, game);
+      }
+      this.sweep();
+      console.log(`[store] restored ${this.games.size} game(s) from ${this.path}`);
+    } catch (err) {
+      console.error(`[store] could not read ${this.path}, starting empty:`, err.message);
+    }
+  }
+
+  flush() {
+    if (!this.path) return;
+    try {
+      mkdirSync(dirname(this.path), { recursive: true });
+      const tmp = `${this.path}.tmp`;
+      writeFileSync(tmp, JSON.stringify({ games: [...this.games.values()] }));
+      renameSync(tmp, this.path);   // atomic, so a crash mid-write cannot corrupt it
+    } catch (err) {
+      console.error('[store] flush failed:', err.message);
+    }
+  }
+
+  /** Coalesce the writes a burst of player actions would otherwise cause. */
+  touch() {
+    if (!this.path || this.timer) return;
+    this.timer = setTimeout(() => {
+      this.timer = null;
+      this.flush();
+    }, FLUSH_MS);
+    this.timer.unref?.();
+  }
+
+  get(code) {
+    return this.games.get(code);
+  }
+
+  set(game) {
+    this.games.set(game.code, game);
+    this.touch();
+    return game;
+  }
+
+  delete(code) {
+    const gone = this.games.delete(code);
+    if (gone) this.touch();
+    return gone;
+  }
+
+  sweep(now = Date.now()) {
+    let dropped = 0;
+    for (const [code, game] of this.games) {
+      if (now - (game.lastActivity ?? game.createdAt) > MAX_AGE_MS) {
+        this.games.delete(code);
+        dropped++;
+      }
+    }
+    if (dropped) this.touch();
+    return dropped;
+  }
+}

--- a/mooncoin/vercel.json
+++ b/mooncoin/vercel.json
@@ -1,0 +1,15 @@
+{
+  "framework": null,
+  "buildCommand": "",
+  "installCommand": "",
+  "outputDirectory": "public",
+  "rewrites": [
+    { "source": "/:code([A-Za-z0-9]{4})", "destination": "/index.html" }
+  ],
+  "headers": [
+    {
+      "source": "/api/(.*)",
+      "headers": [{ "key": "Cache-Control", "value": "no-store, max-age=0" }]
+    }
+  ]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -3,5 +3,5 @@
   "outputDirectory": ".",
   "framework": null,
   "installCommand": "",
-  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- . ':!trading-sim' ':!trading-sim2'"
+  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- . ':!trading-sim' ':!trading-sim2' ':!mooncoin'"
 }


### PR DESCRIPTION
Ports the `mooncoin base game_master` sheet and its Apps Script to a multiplayer web app. Each player gets a private screen on their own phone, the shared dashboard goes on the big screen, and the host drives the round from a third — all off one four-character room code.

Everything lives in `mooncoin/`, following the `trading-sim` pattern of a self-contained project directory.

## Deploying this — two steps, both needed

**1. New Vercel project, root directory `mooncoin`.** It deploys independently of the static site at the repo root, same as `trading-sim`. Branch previews then work normally.

**2. Add a Redis store, or the game will not work properly.** Vercel dashboard → Storage → Upstash for Redis → connect it to the project → redeploy. That injects `KV_REST_API_URL` and `KV_REST_API_TOKEN`, which the store picks up automatically.

Serverless functions share no memory, so game state has to live somewhere both requests can reach. Without Redis the app still boots and every screen shows a warning, but consecutive requests can land on different instances holding different games and tables will appear to vanish.

## The market

Orders carry no limit price — only a signed quantity and a type. MARKET demands immediacy and always fills. LIMIT rests at the last sale, absorbs pressure coming the other way, and fills at the clearing price or not at all.

```
pressure  = market buys - market sells
resting   = limit orders facing that pressure
absorbed  = min(|pressure|, resting)
imbalance = sign(pressure) * (|pressure| - absorbed)

print = last mark + sign(imbalance) * ceil(sqrt(|imbalance|))
```

Everyone who trades that round trades at that one price. A resting order on the *same* side as the pressure is not marketable — nobody sells at last sale into a bid — so it absorbs nothing and does not trade.

Square-root impact is the only governor on size, and it is enough: a 100-lot market order into an empty book moves the print ten points against itself.

There are two prices per round. You trade at the **print**, struck off the old mark by order flow; you are marked at the **mark**, which the dice set afterwards.

## Four things the sheet got wrong

These were bugs rather than design, and are fixed:

1. **The magnitude side of NET was dead.** `Terminal!T7:T16` was hardcoded to `0` instead of `=P+R`, so every multiply and add card, and the entire type-regime, silently did nothing.
2. **Card inventory only decremented for `↑`.** The other three counters were hardcoded, so those cards could be spent forever.
3. **The trade blotter was typed by hand.** The engine writes fills now, so the "Players Record Trades" step is gone.
4. **Dealing ignored the player count.** The Apps Script always dealt ten hands and silently short-handed later players once the hundred-card deck ran dry.

Options were scaffolded in the sheet but never built, and stay out of scope. Fills are keyed individually rather than assuming one instrument, so adding them later is an extension rather than a rewrite.

## Architecture

Polling, not sockets — serverless cannot hold a connection open, and the game is turn-based so a tick is indistinguishable from a push. Actions post and get the resulting state straight back, so whoever acted never waits; polling only shows you what other people did. The interval adapts from 0.9s during the dice to 10s on a hidden tab.

One handler serves both the Vercel function and the local dev server, so what runs on a laptop is what runs in production. Redis is spoken over the Upstash REST API with plain fetch — **zero runtime dependencies**. Read-modify-write happens under a lock; without it two players confirming simultaneously would both read the pre-confirm state and one write would erase the other, which on a ready-gate means a round that never trips.

`engine.js` is pure — no state, no I/O. That is what made the Vercel move a transport swap rather than a rewrite.

## Testing

66 tests, no network mocks. The ones that matter most reproduce the spreadsheet exactly:

- **Position** — 40 @ 99 and −30 @ 109 against a 115 mark → 10 shares, avg 69.00, **$460**
- **Dice** — `V7:Y7 = 4,5,5,3` → **+15, trend 1, MULTIPLY**
- **Slippage** — asserted equal to the sheet's `trunc(sqrt(x)+0.99,0)` for every imbalance 1–500

Plus a full two-round game over real HTTP covering hidden information, token-derived roles, seat rejoin, and simultaneous confirms. Verified in a real browser across all three surfaces with a clean console.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N8R4ke5A3qvAsVRr6G5yQq)_